### PR TITLE
chore(deps): update gswagger dependency to v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.11.0
+	go.lumeweb.com/gswagger v0.12.0
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
 	go.lumeweb.com/portal-middleware v0.1.1
 )

--- a/router.go
+++ b/router.go
@@ -84,7 +84,7 @@ type RouteDefinition struct {
 // It applies common middleware and specific middleware based on the RouteDefinition flags.
 // It also registers access control for the route.
 func RegisterRoutes(
-	gRouter Router, // gswagger router with gorilla types
+	gRouter Router,
 	accessSvc core.AccessService,
 	subdomain string,
 	routes []RouteDefinition,


### PR DESCRIPTION
- Updated go.lumeweb.com/gswagger from v0.11.0 to v0.12.0 in go.mod
- Minor cleanup in router.go comments (removed gorilla types reference)