### PR TITLE
feat(router): add GetGroupRouter utility function

### DIFF
--- a/router.go
+++ b/router.go
@@ -21,9 +21,18 @@ const (
 
 type Router = *swagger.Router[echo.HandlerFunc, es.Route]
 
-// GetRouter returns the underlying echo.Echo from a httputil.Router
+// GetRouter returns the underlying echo.Echo from a router.Router
 func GetRouter(r Router) *echo.Echo {
 	return swagger.GetRouter[*echo.Echo, echo.HandlerFunc, es.Route](r.Router())
+}
+
+// GetGroupRouter returns the underlying echo.Group from a router.Router if it is a group
+func GetGroupRouter(r Router) *echo.Group {
+	router := r.Router().Router()
+	if group, ok := router.(*echo.Group); ok {
+		return group
+	}
+	return nil
 }
 
 // NewSwaggerRouter creates a new gswagger Router instance from an echo.Echo with default OpenAPI options.

--- a/router_test.go
+++ b/router_test.go
@@ -256,6 +256,48 @@ func TestWithSortParams(t *testing.T) {
 	assert.Contains(t, def.Querystring["_sort"].Description, "name, date")
 }
 
+func TestGetGroupRouter(t *testing.T) {
+	t.Run("returns group when router is echo.Group", func(t *testing.T) {
+		echoRouter := echo.New()
+
+		// Create a swagger router with the echo router
+		gRouter, err := NewSwaggerRouter(echoRouter, APIInfo().
+			Title("Test API").
+			Version("1.0.0"))
+		require.NoError(t, err)
+
+		// Create a subrouter from the group
+		subRouter, err := gRouter.Group("/test")
+		require.NoError(t, err)
+
+		result := GetGroupRouter(subRouter)
+		assert.NotNil(t, result)
+
+		// Verify group functionality by registering a route
+		result.GET("/route", func(c echo.Context) error {
+			return nil
+		})
+
+		req := httptest.NewRequest("GET", "/test/route", nil)
+		rr := httptest.NewRecorder()
+		echoRouter.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("returns nil when router is not echo.Group", func(t *testing.T) {
+		echoRouter := echo.New()
+
+		// Create a swagger router with the echo router (not a group)
+		gRouter, err := NewSwaggerRouter(echoRouter, APIInfo().
+			Title("Test API").
+			Version("1.0.0"))
+		require.NoError(t, err)
+
+		result := GetGroupRouter(gRouter)
+		assert.Nil(t, result)
+	})
+}
+
 func TestWithFilterParam(t *testing.T) {
 	def := swagger.Definitions{}
 	def = WithFilterParam(def, "age_gt", "Filter ages greater than value", 18)


### PR DESCRIPTION
- Added new GetGroupRouter function to safely extract echo.Group from router
- Included comprehensive test cases covering both group and non-group scenarios
- Updated function documentation to clarify router types