### PR TITLE
feat(router): enhance router initialization and testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.15.0
+	go.lumeweb.com/gswagger v0.16.0
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
 	go.lumeweb.com/portal-middleware v0.1.1
 )

--- a/route_builder_test.go
+++ b/route_builder_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"github.com/stretchr/testify/require"
 	swagger "go.lumeweb.com/gswagger"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,15 @@ func TestNewRoute(t *testing.T) {
 	assert.Equal(t, ACCESS_USER_ROLE, route.Access)
 	assert.NotNil(t, route.Swagger)
 	assert.Empty(t, route.Middlewares)
+
+	// Test route can be registered with NewRouter
+	eRouter, err := NewRouter(APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+
+	_, err = eRouter.AddRoute(route.Method, route.Path, route.Handler, route.Swagger)
+	assert.NoError(t, err)
 }
 
 func TestWithAccess(t *testing.T) {
@@ -29,6 +39,15 @@ func TestWithAccess(t *testing.T) {
 	route := NewRoute("GET", "/test", handler, WithAccess(ACCESS_ADMIN_ROLE))
 
 	assert.Equal(t, ACCESS_ADMIN_ROLE, route.Access)
+
+	// Test route can be registered with NewRouter
+	router, err := NewRouter(APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+
+	_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger)
+	assert.NoError(t, err)
 }
 
 func TestWithMiddlewares(t *testing.T) {
@@ -47,6 +66,15 @@ func TestWithMiddlewares(t *testing.T) {
 	route := NewRoute("GET", "/test", handler, WithMiddlewares(mw1, mw2))
 
 	assert.Len(t, route.Middlewares, 2)
+
+	// Test route can be registered with NewRouter
+	router, err := NewRouter(APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+
+	_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger, route.Middlewares...)
+	assert.NoError(t, err)
 }
 
 func TestWithSwagger(t *testing.T) {
@@ -58,6 +86,15 @@ func TestWithSwagger(t *testing.T) {
 	route := NewRoute("GET", "/test", handler, WithSwagger(swaggerDef))
 
 	assert.Equal(t, "Test Summary", route.Swagger.Summary)
+
+	// Test route can be registered with NewRouter
+	router, err := NewRouter(APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+
+	_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger)
+	assert.NoError(t, err)
 }
 
 func TestRouteExecution(t *testing.T) {
@@ -69,8 +106,13 @@ func TestRouteExecution(t *testing.T) {
 
 	route := NewRoute("GET", "/test", handler)
 
-	router := echo.New()
-	router.Add(route.Method, route.Path, route.Handler)
+	router, err := NewRouter(APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+
+	_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger)
+	assert.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	rr := httptest.NewRecorder()
@@ -79,4 +121,36 @@ func TestRouteExecution(t *testing.T) {
 
 	assert.True(t, called)
 	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestNewRouter(t *testing.T) {
+	t.Run("basic router creation", func(t *testing.T) {
+		info := APIInfo().
+			Title("Test API").
+			Version("1.0.0")
+
+		router, err := NewRouter(info)
+		assert.NoError(t, err)
+		assert.NotNil(t, router)
+	})
+
+	t.Run("router with echo options", func(t *testing.T) {
+		info := APIInfo().
+			Title("Test API").
+			Version("1.0.0")
+
+		// Test with Echo configuration option
+		router, err := NewRouter(info, RouterOption(func(e *echo.Echo) {
+			e.HideBanner = true
+		}))
+		assert.NoError(t, err)
+		assert.NotNil(t, router)
+		assert.True(t, GetRouter(router).HideBanner)
+	})
+
+	t.Run("invalid api info", func(t *testing.T) {
+		// Empty API info should fail validation
+		_, err := NewRouter(APIInfo())
+		assert.Error(t, err)
+	})
 }

--- a/router.go
+++ b/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"fmt"
+	"go.lumeweb.com/gswagger/apirouter"
 	"net/http"
 	"strings"
 
@@ -55,11 +56,14 @@ func GetGroupRouter(r Router) *echo.Group {
 //	    log.Fatal(err)
 //	}
 func NewSwaggerRouter(echoRouter *echo.Echo, info APIInfoDefinition) (Router, error) {
-	router, err := swagger.NewRouter(es.NewRouter(echoRouter), swagger.Options{
+	router, err := swagger.NewRouter(es.NewRouter(echoRouter), swagger.Options[echo.HandlerFunc, echo.MiddlewareFunc, es.Route]{
 		JSONDocumentationPath: SwaggerJSONPath,
 		YAMLDocumentationPath: SwaggerYAMLPath,
 		Openapi: &openapi3.T{
 			Info: info.toOpenAPI(),
+		},
+		FrameworkRouterFactory: func() apirouter.Router[echo.HandlerFunc, echo.MiddlewareFunc, es.Route] {
+			return es.NewRouter(echo.New())
 		},
 	})
 	if err != nil {
@@ -67,6 +71,42 @@ func NewSwaggerRouter(echoRouter *echo.Echo, info APIInfoDefinition) (Router, er
 	}
 
 	return router, nil
+}
+
+// RouterOption defines a function type for configuring an Echo router.
+type RouterOption func(*echo.Echo)
+
+// applyRouterOptions applies all router configuration options to the given Echo instance.
+func applyRouterOptions(e *echo.Echo, opts ...RouterOption) {
+	for _, opt := range opts {
+		opt(e)
+	}
+}
+
+// NewRouter creates a new Echo router with Swagger integration and sensible defaults.
+// This is a convenience wrapper that handles both Echo and Swagger router initialization.
+//
+// Parameters:
+//   - info: API metadata (use APIInfo() builder)
+//   - opts: Optional router configuration options
+//
+// Returns:
+//   - Router: The Swagger-wrapped router
+//   - error: Any initialization error
+//
+// Example:
+//
+//	router, err := NewRouter(APIInfo().
+//	    Title("My API").
+//	    Version("1.0.0"))
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func NewRouter(info APIInfoDefinition, opts ...RouterOption) (Router, error) {
+	e := echo.New()
+	applyRouterOptions(e, opts...)
+
+	return NewSwaggerRouter(e, info)
 }
 
 // Route is an alias for RouteDefinition for backwards compatibility.

--- a/router_test.go
+++ b/router_test.go
@@ -69,8 +69,7 @@ func TestRegisterRoutes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			echoRouter := echo.New()
-			eRouter, err := NewSwaggerRouter(echoRouter, APIInfo().
+			eRouter, err := NewRouter(APIInfo().
 				Title("Test API").
 				Version("1.0.0"))
 			require.NoError(t, err)
@@ -108,7 +107,7 @@ func TestRegisterRoutes(t *testing.T) {
 			for _, route := range tt.routes {
 				req := httptest.NewRequest(route.Method, route.Path, nil)
 				rr := httptest.NewRecorder()
-				echoRouter.ServeHTTP(rr, req)
+				eRouter.ServeHTTP(rr, req)
 				assert.NotEqual(t, http.StatusNotFound, rr.Code)
 			}
 		})
@@ -185,8 +184,7 @@ func TestWithPaginationParams(t *testing.T) {
 }
 
 func TestNewSwaggerRouter(t *testing.T) {
-	echoRouter := echo.New()
-	eRouter, err := NewSwaggerRouter(echoRouter, APIInfo().
+	eRouter, err := NewRouter(APIInfo().
 		Title("Test API").
 		Version("1.0.0"))
 


### PR DESCRIPTION
- Updated gswagger dependency from v0.15.0 to v0.16.0
- Added NewRouter convenience function that combines Echo and Swagger initialization
- Implemented RouterOption pattern for Echo configuration
- Added comprehensive test coverage for router initialization and route registration
- Modified existing tests to use NewRouter instead of direct Echo initialization
- Added FrameworkRouterFactory to swagger.Options to support host-based routing