### PR TITLE
feat: add standardized error response utilities

### DIFF
--- a/route_builder.go
+++ b/route_builder.go
@@ -11,6 +11,29 @@ const (
 	ACCESS_ADMIN_ROLE = "admin" // Administrator access role
 )
 
+// ResponseError defines a standard error response structure for Swagger documentation
+type ResponseError struct {
+	Error string `json:"error"`
+}
+
+// DefineSwaggerErrorResponse creates a Swagger-compatible error response definition.
+func DefineSwaggerErrorResponse(status int, errorMsg string) map[int]any {
+	return map[int]any{
+		status: ResponseError{Error: errorMsg},
+	}
+}
+
+// DefineSwaggerErrorResponses combines multiple error responses for Swagger docs.
+func DefineSwaggerErrorResponses(responses ...map[int]any) map[int]any {
+	combined := make(map[int]any)
+	for _, r := range responses {
+		for code, resp := range r {
+			combined[code] = resp
+		}
+	}
+	return combined
+}
+
 // RouteOption defines a function type for modifying RouteDefinition properties.
 type RouteOption func(*RouteDefinition)
 

--- a/route_builder_test.go
+++ b/route_builder_test.go
@@ -97,6 +97,54 @@ func TestWithSwagger(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestDefineSwaggerErrorResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		errorMsg  string
+		wantError string
+	}{
+		{
+			name:      "not found error",
+			status:    http.StatusNotFound,
+			errorMsg:  "Not found",
+			wantError: "Not found",
+		},
+		{
+			name:      "bad request error",
+			status:    http.StatusBadRequest,
+			errorMsg:  "Invalid input",
+			wantError: "Invalid input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := DefineSwaggerErrorResponse(tt.status, tt.errorMsg)
+			
+			assert.Contains(t, resp, tt.status)
+			responseVal := resp[tt.status].(ResponseError)
+			assert.Equal(t, tt.wantError, responseVal.Error)
+		})
+	}
+}
+
+func TestDefineSwaggerErrorResponses(t *testing.T) {
+	resp1 := DefineSwaggerErrorResponse(http.StatusNotFound, "Not found")
+	resp2 := DefineSwaggerErrorResponse(http.StatusBadRequest, "Bad request")
+	resp3 := DefineSwaggerErrorResponse(http.StatusInternalServerError, "Server error")
+
+	combined := DefineSwaggerErrorResponses(resp1, resp2, resp3)
+
+	assert.Len(t, combined, 3)
+	assert.Contains(t, combined, http.StatusNotFound)
+	assert.Contains(t, combined, http.StatusBadRequest)
+	assert.Contains(t, combined, http.StatusInternalServerError)
+	
+	notFound := combined[http.StatusNotFound].(ResponseError)
+	assert.Equal(t, "Not found", notFound.Error)
+}
+
 func TestRouteExecution(t *testing.T) {
 	called := false
 	handler := func(c echo.Context) error {

--- a/router.go
+++ b/router.go
@@ -243,7 +243,7 @@ func AuthSwagger(
 // - description: A detailed description of the operation.
 // - reqBody: An instance of the request body DTO for schema generation. Can be nil.
 // - respBody: An instance of the success response body DTO for schema generation. Can be nil.
-// - errResp: A map of additional error status codes and example response bodies.
+// - errResp: A map of additional error status codes and response bodies (use DefineSwaggerErrorResponse(s) helpers).
 func BasicSwagger(
 	summary, description string,
 	errResp map[int]any,


### PR DESCRIPTION
- Added ResponseError struct as standard error response format
- Implemented DefineSwaggerErrorResponse helper for single error responses
- Implemented DefineSwaggerErrorResponses helper for combining multiple errors
- Updated BasicSwagger documentation to reference new helpers
- Added comprehensive tests for new error response functionality