### PR TITLE
feat(swagger)!: refactor parameter functions and add SwaggerOption helpers

### DIFF
--- a/route_builder_test.go
+++ b/route_builder_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"github.com/stretchr/testify/require"
+	swagger "go.lumeweb.com/gswagger"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -74,6 +75,110 @@ func TestWithMiddlewares(t *testing.T) {
 
 	_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger, route.Middlewares...)
 	assert.NoError(t, err)
+}
+
+func TestParameterOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		option   SwaggerOption
+		paramKey string
+	}{
+		{
+			name:     "WithPathParam",
+			option:   WithPathParam("id", "Resource ID", "string"),
+			paramKey: "id",
+		},
+		{
+			name:     "WithQueryParam",
+			option:   WithQueryParam("filter", "Filter criteria", "string"),
+			paramKey: "filter",
+		},
+		{
+			name:     "WithHeaderParam",
+			option:   WithHeaderParam("X-Custom-Header", "Custom header", "string"),
+			paramKey: "X-Custom-Header",
+		},
+		{
+			name:     "WithCookieParam",
+			option:   WithCookieParam("session", "Session token", "string"),
+			paramKey: "session",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := swagger.Definitions{}
+			tt.option(&def)
+
+			var params swagger.ParameterValue
+			switch tt.name {
+			case "WithPathParam":
+				params = def.PathParams
+			case "WithQueryParam":
+				params = def.Querystring
+			case "WithHeaderParam":
+				params = def.Headers
+			case "WithCookieParam":
+				params = def.Cookies
+			}
+
+			assert.NotNil(t, params)
+			assert.Contains(t, params, tt.paramKey)
+			assert.Equal(t, "string", params[tt.paramKey].Schema.Value)
+		})
+	}
+}
+
+func TestSwaggerParameterFunctions(t *testing.T) {
+	tests := []struct {
+		name     string
+		fn       func(swagger.Definitions, string, string, any) swagger.Definitions
+		paramKey string
+	}{
+		{
+			name:     "SwaggerPathParam",
+			fn:       SwaggerPathParam,
+			paramKey: "id",
+		},
+		{
+			name:     "SwaggerQueryParam",
+			fn:       SwaggerQueryParam,
+			paramKey: "filter",
+		},
+		{
+			name:     "SwaggerHeaderParam",
+			fn:       SwaggerHeaderParam,
+			paramKey: "X-Custom-Header",
+		},
+		{
+			name:     "SwaggerCookieParam",
+			fn:       SwaggerCookieParam,
+			paramKey: "session",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := swagger.Definitions{}
+			def = tt.fn(def, tt.paramKey, "test description", "string")
+
+			var params swagger.ParameterValue
+			switch tt.name {
+			case "SwaggerPathParam":
+				params = def.PathParams
+			case "SwaggerQueryParam":
+				params = def.Querystring
+			case "SwaggerHeaderParam":
+				params = def.Headers
+			case "SwaggerCookieParam":
+				params = def.Cookies
+			}
+
+			assert.NotNil(t, params)
+			assert.Contains(t, params, tt.paramKey)
+			assert.Equal(t, "string", params[tt.paramKey].Schema.Value)
+		})
+	}
 }
 
 func TestRouteExecution(t *testing.T) {

--- a/router.go
+++ b/router.go
@@ -352,9 +352,9 @@ func FileUploadSwaggerBody(
 	}
 }
 
-// WithPathParam adds a path parameter definition to existing Swagger definitions.
+// SwaggerPathParam adds a path parameter definition to existing Swagger definitions.
 // This is intended to be chained.
-func WithPathParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+func SwaggerPathParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
 	if d.PathParams == nil {
 		d.PathParams = make(swagger.ParameterValue)
 	}
@@ -365,9 +365,9 @@ func WithPathParam(d swagger.Definitions, name, description string, schemaValue 
 	return d
 }
 
-// WithQueryParam adds a query parameter definition to existing Swagger definitions.
+// SwaggerQueryParam adds a query parameter definition to existing Swagger definitions.
 // This is intended to be chained.
-func WithQueryParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+func SwaggerQueryParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
 	if d.Querystring == nil {
 		d.Querystring = make(swagger.ParameterValue)
 	}
@@ -378,9 +378,9 @@ func WithQueryParam(d swagger.Definitions, name, description string, schemaValue
 	return d
 }
 
-// WithHeaderParam adds a header parameter definition to existing Swagger definitions.
+// SwaggerHeaderParam adds a header parameter definition to existing Swagger definitions.
 // This is intended to be chained.
-func WithHeaderParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+func SwaggerHeaderParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
 	if d.Headers == nil {
 		d.Headers = make(swagger.ParameterValue)
 	}
@@ -391,9 +391,9 @@ func WithHeaderParam(d swagger.Definitions, name, description string, schemaValu
 	return d
 }
 
-// WithCookieParam adds a cookie parameter definition to existing Swagger definitions.
+// SwaggerCookieParam adds a cookie parameter definition to existing Swagger definitions.
 // This is intended to be chained.
-func WithCookieParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+func SwaggerCookieParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
 	if d.Cookies == nil {
 		d.Cookies = make(swagger.ParameterValue)
 	}
@@ -420,45 +420,59 @@ func ErrorResponseSwagger(status int, body any) map[int]any {
 	}
 }
 
-// WithPaginationParams adds standard pagination query parameters (_start, _end) to Swagger definitions.
+// SwaggerPaginationParams adds standard pagination query parameters (_start, _end) to Swagger definitions.
 // It takes the base Swagger definitions and returns the modified definitions for chaining.
-func WithPaginationParams(d swagger.Definitions) swagger.Definitions {
+func SwaggerPaginationParams(d swagger.Definitions) swagger.Definitions {
 	if d.Querystring == nil {
 		d.Querystring = make(swagger.ParameterValue)
 	}
 	d.Querystring["_start"] = swagger.Parameter{
 		Description: "Starting index of the items to return (0-based). Defaults to 0.",
-		Schema:      &swagger.Schema{Value: 0}, // Example value for schema generation
+		Schema:      &swagger.Schema{Value: 0},
 	}
 	d.Querystring["_end"] = swagger.Parameter{
 		Description: "Ending index of the items to return (exclusive). Defaults to 10.",
-		Schema:      &swagger.Schema{Value: 10}, // Example value for schema generation
+		Schema:      &swagger.Schema{Value: 10},
 	}
 	return d
 }
 
-// WithSortParams adds standard sorting query parameters (_sort, _order) to Swagger definitions.
-// It takes the base Swagger definitions and returns the modified definitions for chaining.
-//
+// SwaggerSortParams adds standard sorting query parameters (_sort, _order) to Swagger definitions.
 // Parameters:
-// - d: The base Swagger definitions.
+// - d: The base Swagger definitions
 // - sortableFields: A list of fields that can be sorted. Used in the description.
-func WithSortParams(d swagger.Definitions, sortableFields []string) swagger.Definitions {
+func SwaggerSortParams(d swagger.Definitions, sortableFields []string) swagger.Definitions {
 	if d.Querystring == nil {
 		d.Querystring = make(swagger.ParameterValue)
 	}
 	d.Querystring["_sort"] = swagger.Parameter{
 		Description: fmt.Sprintf("Comma-separated list of fields to sort by. Available fields: %s", strings.Join(sortableFields, ", ")),
-		Schema:      &swagger.Schema{Value: ""}, // Example value (string)
+		Schema:      &swagger.Schema{Value: ""},
 	}
 	d.Querystring["_order"] = swagger.Parameter{
 		Description: "Comma-separated list of sort orders ('asc' or 'desc') corresponding to _sort fields. Defaults to 'asc'.",
-		Schema:      &swagger.Schema{Value: ""}, // Example value (string)
+		Schema:      &swagger.Schema{Value: ""},
 	}
 	return d
 }
 
-// WithFilterParam adds a single filter query parameter to Swagger definitions.
+// SortParams returns the standard sorting query parameters (_sort, _order).
+// Parameters:
+// - sortableFields: A list of fields that can be sorted. Used in the description.
+func SortParams(sortableFields []string) swagger.ParameterValue {
+	return swagger.ParameterValue{
+		"_sort": swagger.Parameter{
+			Description: fmt.Sprintf("Comma-separated list of fields to sort by. Available fields: %s", strings.Join(sortableFields, ", ")),
+			Schema:      &swagger.Schema{Value: ""},
+		},
+		"_order": swagger.Parameter{
+			Description: "Comma-separated list of sort orders ('asc' or 'desc') corresponding to _sort fields. Defaults to 'asc'.",
+			Schema:      &swagger.Schema{Value: ""},
+		},
+	}
+}
+
+// SwaggerFilterParam adds a single filter query parameter to Swagger definitions.
 // This helper is for simple filters like `fieldName_operator=value`.
 //
 // Parameters:
@@ -466,7 +480,7 @@ func WithSortParams(d swagger.Definitions, sortableFields []string) swagger.Defi
 // - name: The full query parameter name (e.g., "age_gte", "status_eq").
 // - description: Description of the filter parameter.
 // - schemaValue: An example value for schema generation (e.g., 30, "active").
-func WithFilterParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+func SwaggerFilterParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
 	if d.Querystring == nil {
 		d.Querystring = make(swagger.ParameterValue)
 	}
@@ -477,17 +491,27 @@ func WithFilterParam(d swagger.Definitions, name, description string, schemaValu
 	return d
 }
 
-// WithGlobalSearchParam adds the standard global search query parameter ('q') to Swagger definitions.
-// It takes the base Swagger definitions and returns the modified definitions for chaining.
-func WithGlobalSearchParam(d swagger.Definitions) swagger.Definitions {
+
+// SwaggerGlobalSearchParam adds the standard global search query parameter ('q') to Swagger definitions.
+func SwaggerGlobalSearchParam(d swagger.Definitions) swagger.Definitions {
 	if d.Querystring == nil {
 		d.Querystring = make(swagger.ParameterValue)
 	}
 	d.Querystring["q"] = swagger.Parameter{
 		Description: "Global search query string.",
-		Schema:      &swagger.Schema{Value: ""}, // Example value (string)
+		Schema:      &swagger.Schema{Value: ""},
 	}
 	return d
+}
+
+// GlobalSearchParam returns the standard global search query parameter ('q').
+func GlobalSearchParam() swagger.ParameterValue {
+	return swagger.ParameterValue{
+		"q": swagger.Parameter{
+			Description: "Global search query string.",
+			Schema:      &swagger.Schema{Value: ""},
+		},
+	}
 }
 
 // FilterParam defines the details for a single filter query parameter.
@@ -517,42 +541,42 @@ func ListEndpointSwagger(
 	filterParams []FilterParam,
 	errResp map[int]any,
 ) swagger.Definitions {
-	// Start with the base Swagger definitions (authenticated or public)
-	var definitions swagger.Definitions
+	// Start with either AuthSwagger or BasicSwagger based on purpose
+	var def swagger.Definitions
 	if purpose != jwt.PurposeNone {
-		definitions = AuthSwagger(summary, description, purpose, errResp)
+		def = AuthSwagger(summary, description, purpose, errResp)
 	} else {
-		definitions = BasicSwagger(summary, description, errResp)
+		def = BasicSwagger(summary, description, errResp)
 	}
 
-	// Add standard query parameters using the chaining helpers
-	definitions = WithPaginationParams(definitions)
-	definitions = WithSortParams(definitions, sortableFields)
-	definitions = WithGlobalSearchParam(definitions)
+	// Apply standard list endpoint options
+	def = SwaggerPaginationParams(def)
+	def = SwaggerSortParams(def, sortableFields)
+	def = SwaggerGlobalSearchParam(def)
 
-	// Add specific filter parameters
+	// Add filter parameters
 	for _, fp := range filterParams {
-		definitions = WithQueryParam(definitions, fp.Name, fp.Description, fp.SchemaValue)
+		def = SwaggerFilterParam(def, fp.Name, fp.Description, fp.SchemaValue)
 	}
 
-	// Update the 200 OK response content with the paginated schema
-	// Use PaginatedResponseSwagger logic directly
-	paginatedResponseSchema := map[string]any{
+	// Define the paginated response schema
+	paginatedResponse := map[string]any{
 		"items": map[string]any{
 			"type":  "array",
-			"items": itemSchema, // Schema for a single item
+			"items": itemSchema,
 		},
 	}
 	if paginationSchema != nil {
-		paginatedResponseSchema["pagination"] = paginationSchema
+		paginatedResponse["pagination"] = paginationSchema
 	}
 
-	definitions.Responses[http.StatusOK] = swagger.ContentValue{
+	// Update the success response
+	def.Responses[http.StatusOK] = swagger.ContentValue{
 		Description: "Success",
-		Content:     swagger.Content{"application/json": {Value: paginatedResponseSchema}},
+		Content:     swagger.Content{"application/json": {Value: paginatedResponse}},
 	}
 
-	return definitions
+	return def
 }
 
 // Schema helpers provide safe access to schema fields

--- a/router_test.go
+++ b/router_test.go
@@ -158,29 +158,33 @@ func TestBasicSwagger(t *testing.T) {
 	assert.NotContains(t, def.Security, "bearerAuth")
 }
 
-func TestWithPathParam(t *testing.T) {
+func TestSwaggerPathParam(t *testing.T) {
 	def := swagger.Definitions{}
-	def = WithPathParam(def, "id", "Test ID", "string")
+	def = SwaggerPathParam(def, "id", "Test ID", "string")
 
 	assert.NotNil(t, def.PathParams)
 	assert.Equal(t, "Test ID", def.PathParams["id"].Description)
+	assert.Equal(t, "string", def.PathParams["id"].Schema.Value)
 }
 
-func TestWithQueryParam(t *testing.T) {
+func TestSwaggerQueryParam(t *testing.T) {
 	def := swagger.Definitions{}
-	def = WithQueryParam(def, "filter", "Test filter", "string")
+	def = SwaggerQueryParam(def, "filter", "Test filter", "string")
 
 	assert.NotNil(t, def.Querystring)
 	assert.Equal(t, "Test filter", def.Querystring["filter"].Description)
+	assert.Equal(t, "string", def.Querystring["filter"].Schema.Value)
 }
 
-func TestWithPaginationParams(t *testing.T) {
+func TestSwaggerPaginationParams(t *testing.T) {
 	def := swagger.Definitions{}
-	def = WithPaginationParams(def)
+	def = SwaggerPaginationParams(def)
 
 	assert.NotNil(t, def.Querystring)
 	assert.Contains(t, def.Querystring, "_start")
 	assert.Contains(t, def.Querystring, "_end")
+	assert.Equal(t, 0, def.Querystring["_start"].Schema.Value)
+	assert.Equal(t, 10, def.Querystring["_end"].Schema.Value)
 }
 
 func TestNewSwaggerRouter(t *testing.T) {
@@ -246,12 +250,14 @@ func TestSwaggerDocsServed(t *testing.T) {
 
 func TestWithSortParams(t *testing.T) {
 	def := swagger.Definitions{}
-	def = WithSortParams(def, []string{"name", "date"})
+	def = SwaggerSortParams(def, []string{"name", "date"})
 
 	assert.NotNil(t, def.Querystring)
 	assert.Contains(t, def.Querystring, "_sort")
 	assert.Contains(t, def.Querystring, "_order")
 	assert.Contains(t, def.Querystring["_sort"].Description, "name, date")
+	assert.Equal(t, "", def.Querystring["_sort"].Schema.Value)
+	assert.Equal(t, "", def.Querystring["_order"].Schema.Value)
 }
 
 func TestGetGroupRouter(t *testing.T) {
@@ -296,14 +302,34 @@ func TestGetGroupRouter(t *testing.T) {
 	})
 }
 
-func TestWithFilterParam(t *testing.T) {
+func TestSwaggerFilterParam(t *testing.T) {
 	def := swagger.Definitions{}
-	def = WithFilterParam(def, "age_gt", "Filter ages greater than value", 18)
+	def = SwaggerFilterParam(def, "age_gt", "Filter ages greater than value", 18)
 
 	assert.NotNil(t, def.Querystring)
 	assert.Contains(t, def.Querystring, "age_gt")
 	assert.Equal(t, "Filter ages greater than value", def.Querystring["age_gt"].Description)
 	assert.Equal(t, 18, def.Querystring["age_gt"].Schema.Value)
+}
+
+func TestSwaggerHeaderParam(t *testing.T) {
+	def := swagger.Definitions{}
+	def = SwaggerHeaderParam(def, "X-Custom-Header", "Custom header value", "string")
+
+	assert.NotNil(t, def.Headers)
+	assert.Contains(t, def.Headers, "X-Custom-Header")
+	assert.Equal(t, "Custom header value", def.Headers["X-Custom-Header"].Description)
+	assert.Equal(t, "string", def.Headers["X-Custom-Header"].Schema.Value)
+}
+
+func TestSwaggerCookieParam(t *testing.T) {
+	def := swagger.Definitions{}
+	def = SwaggerCookieParam(def, "session", "Session token", "string")
+
+	assert.NotNil(t, def.Cookies)
+	assert.Contains(t, def.Cookies, "session")
+	assert.Equal(t, "Session token", def.Cookies["session"].Description)
+	assert.Equal(t, "string", def.Cookies["session"].Schema.Value)
 }
 
 func TestListEndpointSwagger(t *testing.T) {

--- a/swagger.go
+++ b/swagger.go
@@ -291,3 +291,59 @@ var operatorDocs = map[string]string{
 	"nina":         "Array does not contain any of the specified values",
 	"like":         "Case-insensitive contains (alias for contains)",
 }
+
+// WithPathParam creates a SwaggerOption that adds a path parameter definition.
+func WithPathParam(name, description string, schemaValue any) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = SwaggerPathParam(*d, name, description, schemaValue)
+	}
+}
+
+// WithQueryParam creates a SwaggerOption that adds a query parameter definition.
+func WithQueryParam(name, description string, schemaValue any) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = SwaggerQueryParam(*d, name, description, schemaValue)
+	}
+}
+
+// WithHeaderParam creates a SwaggerOption that adds a header parameter definition.
+func WithHeaderParam(name, description string, schemaValue any) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = SwaggerHeaderParam(*d, name, description, schemaValue)
+	}
+}
+
+// WithCookieParam creates a SwaggerOption that adds a cookie parameter definition.
+func WithCookieParam(name, description string, schemaValue any) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = SwaggerCookieParam(*d, name, description, schemaValue)
+	}
+}
+
+// WithFilterParam creates a SwaggerOption that adds a filter parameter.
+func WithFilterParam(name, description string, schemaValue any) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = SwaggerFilterParam(*d, name, description, schemaValue)
+	}
+}
+
+// WithPaginationParams creates a SwaggerOption that adds standard pagination parameters.
+func WithPaginationParams() SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = SwaggerPaginationParams(*d)
+	}
+}
+
+// WithSortParams creates a SwaggerOption that adds standard sorting parameters.
+func WithSortParams(sortableFields []string) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = SwaggerSortParams(*d, sortableFields)
+	}
+}
+
+// WithGlobalSearchParam creates a SwaggerOption that adds the global search parameter.
+func WithGlobalSearchParam() SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = SwaggerGlobalSearchParam(*d)
+	}
+}


### PR DESCRIPTION
- Renamed all parameter helper functions from WithXxx to SwaggerXxx for consistency
- Added new SwaggerOption helper functions (WithXxx) that wrap the SwaggerXxx functions
- Added comprehensive tests for all parameter functions
- Improved test coverage with schema value assertions
- Added helper functions to return parameter values directly (SortParams, GlobalSearchParam)
- Cleaned up ListEndpointSwagger implementation