### PR TITLE
refactor(router): partially copy AccessService interface from core to router package

### DIFF
--- a/route_builder.go
+++ b/route_builder.go
@@ -5,6 +5,15 @@ import (
 	swagger "go.lumeweb.com/gswagger"
 )
 
+// AccessService defines the interface for route access control
+type AccessService interface {
+	// CheckAccess verifies if a user has access to a specific route
+	CheckAccess(userId uint, fqdn, path, method string) (bool, error)
+	
+	// RegisterRoute registers a new route with its access requirements
+	RegisterRoute(subdomain, path, method, role string) error
+}
+
 // Common access role constants
 const (
 	ACCESS_USER_ROLE  = "user"  // Standard user access role

--- a/router.go
+++ b/router.go
@@ -11,7 +11,6 @@ import (
 	swagger "go.lumeweb.com/gswagger"
 	es "go.lumeweb.com/gswagger/support/echo"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
-	"go.lumeweb.com/portal/core"
 )
 
 const (
@@ -133,7 +132,7 @@ type RouteDefinition struct {
 // It also registers access control for protected routes if an access service is provided.
 func RegisterRoutes(
 	gRouter Router,
-	accessSvc core.AccessService,
+	accessSvc AccessService,
 	subdomain string,
 	routes []RouteDefinition,
 	commonMiddleware ...echo.MiddlewareFunc,
@@ -490,7 +489,6 @@ func SwaggerFilterParam(d swagger.Definitions, name, description string, schemaV
 	}
 	return d
 }
-
 
 // SwaggerGlobalSearchParam adds the standard global search query parameter ('q') to Swagger definitions.
 func SwaggerGlobalSearchParam(d swagger.Definitions) swagger.Definitions {


### PR DESCRIPTION
- Copied AccessService interface definition from core/access.go to route_builder.go
- Updated RegisterRoutes function to use local AccessService interface instead of core.AccessService
- Kept access role constants (ACCESS_USER_ROLE, ACCESS_ADMIN_ROLE) in route_builder.go