### PR TITLE
feat(swagger): enhance response handling and filter parameter generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	go.lumeweb.com/gswagger v0.16.1
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
 	go.lumeweb.com/portal-middleware v0.2.5
+	go.lumeweb.com/queryutil v0.3.2
 )
 
 require (
@@ -53,7 +54,7 @@ require (
 	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2 // indirect
 	github.com/gotd/contrib v0.21.0 // indirect
 	github.com/hbollon/go-edlib v1.6.0 // indirect
-	github.com/invopop/jsonschema v0.12.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
@@ -100,10 +101,11 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/tools v0.31.0 // indirect
+	golang.org/x/tools v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	google.golang.org/grpc v1.71.0 // indirect

--- a/router.go
+++ b/router.go
@@ -557,24 +557,10 @@ func ListEndpointSwagger(
 		def = SwaggerFilterParam(def, fp.Name, fp.Description, fp.SchemaValue)
 	}
 
-	// Define the paginated response schema
-	paginatedResponse := map[string]any{
-		"items": map[string]any{
-			"type":  "array",
-			"items": itemSchema,
-		},
-	}
-	if paginationSchema != nil {
-		paginatedResponse["pagination"] = paginationSchema
-	}
-
-	// Update the success response
-	def.Responses[http.StatusOK] = swagger.ContentValue{
-		Description: "Success",
-		Content:     swagger.Content{"application/json": {Value: paginatedResponse}},
-	}
-
-	return def
+	// Use WithPaginatedResponse helper for the success response
+	return applyOpts(def, []SwaggerOption{
+		WithPaginatedResponse(itemSchema, paginationSchema),
+	})
 }
 
 // Schema helpers provide safe access to schema fields

--- a/swagger.go
+++ b/swagger.go
@@ -1,7 +1,10 @@
 package router
 
 import (
+	"fmt"
 	swagger "go.lumeweb.com/gswagger"
+	"go.lumeweb.com/portal-middleware/auth/jwt"
+	"go.lumeweb.com/queryutil/filter"
 	"net/http"
 	"strings"
 )
@@ -205,10 +208,121 @@ func createOperatorSchemas(ops []string) map[string]any {
 	return schemas
 }
 
+// Response defines a standardized response structure
+type Response struct {
+	Description string
+	Content     *Content
+	Headers     []Header
+}
+
+// Content defines the response content for a specific media type
+type Content struct {
+	MediaType string
+	Schema    interface{}
+}
+
+// Header represents a single response header
+type Header struct {
+	Name  string
+	Value string
+}
+
+// ResponseOption defines a function type for modifying Response properties
+type ResponseOption func(*Response)
+
 // ResponseError is a placeholder struct to define the schema for error responses.
 // This struct is used by the Swagger documentation generation.
 type ResponseError struct {
 	Error string `json:"error"`
+}
+
+// WithContent creates a ResponseOption that sets the response content
+func WithContent(mediaType string, schema interface{}) ResponseOption {
+	return func(r *Response) {
+		r.Content = &Content{
+			MediaType: mediaType,
+			Schema:    schema,
+		}
+	}
+}
+
+// WithHeader creates a ResponseOption that adds a response header
+func WithHeader(name, description string) ResponseOption {
+	return func(r *Response) {
+		r.Headers = append(r.Headers, Header{
+			Name:  name,
+			Value: description,
+		})
+	}
+}
+
+// WithJSONContent helper for common JSON responses
+func WithJSONContent(schema interface{}) ResponseOption {
+	return WithContent("application/json", schema)
+}
+
+// WithTotalCountHeader adds the X-Total-Count header to a response
+func WithTotalCountHeader() ResponseOption {
+	return WithHeader("X-Total-Count", "Total number of items")
+}
+
+// WithCacheControl helper for cache headers
+func WithCacheControl(value string) ResponseOption {
+	return WithHeader("Cache-Control", value)
+}
+
+// DefineResponse creates a Response with the given status code and options
+func DefineResponse(status int, description string, opts ...ResponseOption) map[int]swagger.ContentValue {
+	r := Response{
+		Description: description,
+	}
+
+	for _, opt := range opts {
+		opt(&r)
+	}
+
+	// Convert to swagger format (internal only)
+	headers := make(map[string]string)
+	for _, h := range r.Headers {
+		headers[h.Name] = h.Value
+	}
+
+	contentValue := swagger.ContentValue{
+		Description: r.Description,
+		Headers:     headers,
+	}
+
+	if r.Content != nil {
+		contentValue.Content = swagger.Content{
+			r.Content.MediaType: swagger.Schema{Value: r.Content.Schema},
+		}
+	}
+
+	return map[int]swagger.ContentValue{
+		status: contentValue,
+	}
+}
+
+// WithSuccessResponse creates a SwaggerOption that adds a success response
+func WithSuccessResponse(status int, description string, opts ...ResponseOption) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		if d.Responses == nil {
+			d.Responses = make(map[int]swagger.ContentValue)
+		}
+		for code, resp := range DefineResponse(status, description, opts...) {
+			d.Responses[code] = resp
+		}
+	}
+}
+
+// WithPaginatedResponse creates a paginated list response helper
+func WithPaginatedResponse(itemType interface{}, paginationMeta interface{}) SwaggerOption {
+	return WithSuccessResponse(http.StatusOK, "Success",
+		WithJSONContent(map[string]interface{}{
+			"items":      []interface{}{itemType},
+			"pagination": paginationMeta,
+		}),
+	)
 }
 
 // DefineSwaggerErrorResponse creates a Swagger-compatible error response definition.
@@ -327,6 +441,65 @@ func WithFilterParam(name, description string, schemaValue any) SwaggerOption {
 	}
 }
 
+// WithFilterParamsFromSchema creates a SwaggerOption that adds all filter parameters
+// from a FieldSchema's FilterOperators() map. Supports multiple formats:
+// - Simple: field_operator=value (e.g. age_gt=30)
+// - Array values: field_operator=value1,value2,value3 or field_operator[]=value1&field_operator[]=value2
+// - Complex: filters[field][operator]=value (e.g. filters[age][gt]=30)
+func WithFilterParamsFromSchema(schema FieldSchema) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		operators := schema.FilterOperators()
+		for fieldName, ops := range operators {
+			for _, op := range ops {
+				// Validate operator string
+				if _, exists := operatorDocs[op]; !exists {
+					continue // Skip unknown operators
+				}
+				// Determine if this operator expects array values
+				isArrayOp := opIsMultiValue(filter.Operator(op)) ||
+					filter.Operator(op) == filter.OpBetween || filter.Operator(op) == filter.OpNbetween
+
+				// Add simple format param
+				simpleParam := fmt.Sprintf("%s_%s", fieldName, op)
+				paramDesc := fmt.Sprintf("Filter by %s %s",
+					fieldName, strings.ToLower(op))
+
+				if isArrayOp {
+					// Array parameter schema
+					*d = SwaggerFilterParam(*d, simpleParam, paramDesc,
+						map[string]interface{}{
+							"type": "array",
+							"items": map[string]interface{}{
+								"type": "string", // Will be converted by parser
+							},
+							"style":              "form",
+							"explode":            false,
+							"x-csv":              true,
+							"x-collectionFormat": "multi",
+						})
+				} else {
+					// Single value parameter
+					*d = SwaggerFilterParam(*d, simpleParam, paramDesc, nil)
+				}
+
+				// Add complex format param
+				complexParam := fmt.Sprintf("filters[%s][%s]", fieldName, op)
+				*d = SwaggerFilterParam(*d, complexParam,
+					fmt.Sprintf("Filter by %s %s",
+						fieldName, strings.ToLower(op)),
+					nil)
+			}
+		}
+	}
+}
+
+// opIsMultiValue checks if an operator expects multiple values
+func opIsMultiValue(op filter.Operator) bool {
+	return op == filter.OpIn || op == filter.OpNin ||
+		op == filter.OpIna || op == filter.OpNina ||
+		op == filter.OpBetween || op == filter.OpNbetween
+}
+
 // WithPaginationParams creates a SwaggerOption that adds standard pagination parameters.
 func WithPaginationParams() SwaggerOption {
 	return func(d *swagger.Definitions) {
@@ -345,5 +518,29 @@ func WithSortParams(sortableFields []string) SwaggerOption {
 func WithGlobalSearchParam() SwaggerOption {
 	return func(d *swagger.Definitions) {
 		*d = SwaggerGlobalSearchParam(*d)
+	}
+}
+
+// WithListEndpoint creates a SwaggerOption for a typical list endpoint with pagination, sorting and filtering.
+func WithListEndpoint(
+	summary, description string,
+	purpose jwt.Purpose,
+	itemSchema any,
+	paginationSchema any,
+	sortableFields []string,
+	filterParams []FilterParam,
+	errResp map[int]any,
+) SwaggerOption {
+	return func(d *swagger.Definitions) {
+		*d = ListEndpointSwagger(
+			summary,
+			description,
+			purpose,
+			itemSchema,
+			paginationSchema,
+			sortableFields,
+			filterParams,
+			errResp,
+		)
 	}
 }

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -2,12 +2,29 @@ package router
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	swagger "go.lumeweb.com/gswagger"
+	"go.lumeweb.com/queryutil/filter"
 )
+
+// Define a test schema that implements FieldSchema
+type testSchema struct{}
+
+func (s *testSchema) FilterOperators() map[string][]string {
+	return map[string][]string{
+		"age":  {"gt", "lt", "between"},
+		"name": {"contains", "startswith"},
+	}
+}
+
+func (s *testSchema) SortableFields() []string {
+	return []string{"age", "name"}
+}
 
 func TestWithSwaggerOptions(t *testing.T) {
 	handler := func(c echo.Context) error { return nil }
@@ -15,6 +32,96 @@ func TestWithSwaggerOptions(t *testing.T) {
 	route := NewRoute("GET", "/test", handler, WithSwaggerOptions(WithSummary("Test Summary")))
 
 	assert.Equal(t, "Test Summary", route.Swagger.Summary)
+}
+
+func TestWithFilterParamsFromSchema(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		schema        FieldSchema
+		wantParams    []string
+		wantArrayOps  []string
+		wantDescRegex string
+	}{
+		{
+			name:   "basic field operators",
+			schema: &testSchema{},
+			wantParams: []string{
+				"age_gt",
+				"age_lt",
+				"age_between",
+				"name_contains",
+				"name_startswith",
+				"filters[age][gt]",
+				"filters[age][lt]",
+				"filters[age][between]",
+				"filters[name][contains]",
+				"filters[name][startswith]",
+			},
+			wantArrayOps:  []string{"age_between"},
+			wantDescRegex: `Filter by (age|name)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create route with filter params
+			def := swagger.Definitions{}
+			WithFilterParamsFromSchema(tt.schema)(&def)
+
+			// Verify all expected parameters exist
+			for _, param := range tt.wantParams {
+				assert.Contains(t, def.Querystring, param, "missing parameter: %s", param)
+			}
+
+			// Verify array parameter schemas
+			for _, param := range tt.wantArrayOps {
+				schema := def.Querystring[param].Schema.Value
+				schemaMap, ok := schema.(map[string]interface{})
+				require.True(t, ok, "expected map schema for %s", param)
+
+				assert.Equal(t, "array", schemaMap["type"])
+				assert.Equal(t, true, schemaMap["x-csv"])
+				assert.Equal(t, "multi", schemaMap["x-collectionFormat"])
+			}
+
+			// Verify descriptions contain expected text and complex format structure
+			for param, paramDef := range def.Querystring {
+				assert.Regexp(t, tt.wantDescRegex, paramDef.Description,
+					"unexpected description for %s", param)
+
+				// Verify complex format params have correct structure
+				if strings.Contains(param, "filters[") {
+					assert.Contains(t, param, "[", "complex format param should contain brackets")
+					assert.Contains(t, param, "]", "complex format param should contain brackets")
+				}
+
+			}
+		})
+	}
+}
+
+func TestOpIsMultiValue(t *testing.T) {
+	tests := []struct {
+		name string
+		op   string
+		want bool
+	}{
+		{"OpIn", "in", true},
+		{"OpNin", "nin", true},
+		{"OpIna", "ina", true},
+		{"OpNina", "nina", true},
+		{"OpBetween", "between", true},
+		{"OpNbetween", "nbetween", true},
+		{"OpEq", "eq", false},
+		{"OpContains", "contains", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, opIsMultiValue(filter.Operator(tt.op)))
+		})
+	}
 }
 
 func TestWithRequestBody(t *testing.T) {
@@ -77,10 +184,130 @@ func TestWithResponseHeaders(t *testing.T) {
 	assert.Contains(t, def.Responses, http.StatusOK)
 	resp := def.Responses[http.StatusOK]
 	assert.Equal(t, "Success", resp.Description)
-	// Assert that the Content is of type swagger.Content and has the expected content
 	assert.IsType(t, swagger.Content{}, resp.Content)
-	assert.Equal(t, content, map[string]swagger.Schema(resp.Content)) // Cast swagger.Content back to map for comparison
+	assert.Equal(t, content, map[string]swagger.Schema(resp.Content))
 	assert.Equal(t, headers, resp.Headers)
+}
+
+func TestResponseHelpers(t *testing.T) {
+	t.Run("WithContent", func(t *testing.T) {
+		resp := &Response{}
+		WithContent("application/json", "test")(resp)
+		assert.Equal(t, "application/json", resp.Content.MediaType)
+		assert.Equal(t, "test", resp.Content.Schema)
+	})
+
+	t.Run("WithHeader", func(t *testing.T) {
+		resp := &Response{}
+		WithHeader("X-Test", "Test header")(resp)
+		assert.Len(t, resp.Headers, 1)
+		assert.Equal(t, "X-Test", resp.Headers[0].Name)
+		assert.Equal(t, "Test header", resp.Headers[0].Value)
+	})
+
+	t.Run("WithJSONContent", func(t *testing.T) {
+		resp := &Response{}
+		WithJSONContent("test")(resp)
+		assert.Equal(t, "application/json", resp.Content.MediaType)
+		assert.Equal(t, "test", resp.Content.Schema)
+	})
+
+	t.Run("WithTotalCountHeader", func(t *testing.T) {
+		resp := &Response{}
+		WithTotalCountHeader()(resp)
+		assert.Len(t, resp.Headers, 1)
+		assert.Equal(t, "X-Total-Count", resp.Headers[0].Name)
+	})
+
+	t.Run("WithCacheControl", func(t *testing.T) {
+		resp := &Response{}
+		WithCacheControl("no-cache")(resp)
+		assert.Len(t, resp.Headers, 1)
+		assert.Equal(t, "Cache-Control", resp.Headers[0].Name)
+		assert.Equal(t, "no-cache", resp.Headers[0].Value)
+	})
+
+	t.Run("DefineResponse", func(t *testing.T) {
+		resp := DefineResponse(http.StatusOK, "Success",
+			WithJSONContent("test"),
+			WithTotalCountHeader(),
+		)
+		assert.Contains(t, resp, http.StatusOK)
+		assert.Equal(t, "Success", resp[http.StatusOK].Description)
+		assert.Equal(t, "test", resp[http.StatusOK].Content["application/json"].Value)
+		assert.Equal(t, "Total number of items", resp[http.StatusOK].Headers["X-Total-Count"])
+	})
+
+	t.Run("WithSuccessResponse", func(t *testing.T) {
+		def := swagger.Definitions{}
+		WithSuccessResponse(http.StatusOK, "Success",
+			WithJSONContent("test"),
+			WithTotalCountHeader(),
+		)(&def)
+
+		assert.Contains(t, def.Responses, http.StatusOK)
+		resp := def.Responses[http.StatusOK]
+		assert.Equal(t, "Success", resp.Description)
+		assert.Equal(t, "test", resp.Content["application/json"].Value)
+		assert.Equal(t, "Total number of items", resp.Headers["X-Total-Count"])
+	})
+
+	t.Run("WithPaginatedResponse", func(t *testing.T) {
+		type Item struct{ Name string }
+		type Meta struct{ Total int }
+
+		def := swagger.Definitions{}
+		WithPaginatedResponse(Item{}, Meta{})(&def)
+
+		assert.Contains(t, def.Responses, http.StatusOK)
+		resp := def.Responses[http.StatusOK]
+		assert.Equal(t, "Success", resp.Description)
+
+		content := resp.Content["application/json"].Value.(map[string]interface{})
+		assert.NotNil(t, content["items"])
+		assert.NotNil(t, content["pagination"])
+	})
+
+	t.Run("DefineSwaggerErrorResponse", func(t *testing.T) {
+		resp := DefineSwaggerErrorResponse(http.StatusNotFound, "Not Found")
+		assert.Contains(t, resp, http.StatusNotFound)
+		assert.Equal(t, "Not Found", resp[http.StatusNotFound].Description)
+		assert.Equal(t, "Not Found", resp[http.StatusNotFound].Content["application/json"].Value.(ResponseError).Error)
+	})
+
+	t.Run("DefineSwaggerErrorResponses", func(t *testing.T) {
+		resp1 := DefineSwaggerErrorResponse(http.StatusNotFound, "Not Found")
+		resp2 := DefineSwaggerErrorResponse(http.StatusBadRequest, "Bad Request")
+		combined := DefineSwaggerErrorResponses(resp1, resp2)
+
+		assert.Contains(t, combined, http.StatusNotFound)
+		assert.Contains(t, combined, http.StatusBadRequest)
+		assert.Equal(t, "Not Found", combined[http.StatusNotFound].Description)
+		assert.Equal(t, "Bad Request", combined[http.StatusBadRequest].Description)
+	})
+
+	t.Run("DefaultCoreErrorResponses", func(t *testing.T) {
+		resp := DefaultCoreErrorResponses()
+		assert.Contains(t, resp, http.StatusBadRequest)
+		assert.Contains(t, resp, http.StatusNotFound)
+		assert.Contains(t, resp, http.StatusInternalServerError)
+	})
+
+	t.Run("DefaultPublicErrorResponses", func(t *testing.T) {
+		resp := DefaultPublicErrorResponses()
+		assert.Contains(t, resp, http.StatusBadRequest)
+		assert.Contains(t, resp, http.StatusNotFound)
+		assert.Contains(t, resp, http.StatusInternalServerError)
+	})
+
+	t.Run("DefaultAuthErrorResponses", func(t *testing.T) {
+		resp := DefaultAuthErrorResponses()
+		assert.Contains(t, resp, http.StatusBadRequest)
+		assert.Contains(t, resp, http.StatusNotFound)
+		assert.Contains(t, resp, http.StatusInternalServerError)
+		assert.Contains(t, resp, http.StatusUnauthorized)
+		assert.Contains(t, resp, http.StatusForbidden)
+	})
 }
 
 func TestWithTags(t *testing.T) {


### PR DESCRIPTION
- Added new response helper functions (WithContent, WithHeader, WithJSONContent etc.)
- Implemented WithFilterParamsFromSchema to auto-generate filter parameters from schema
- Added WithPaginatedResponse helper for standardized paginated responses
- Introduced Response struct and related options for better response handling
- Added comprehensive test coverage for new functionality
- Updated dependencies (go.lumeweb.com/queryutil, github.com/invopop/jsonschema)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced API documentation with more modular and expressive Swagger response definitions.
  - Added comprehensive support for paginated, filtered, and sorted list endpoints in API documentation.
  - Improved automatic generation of filter query parameters in API documentation.

- **Bug Fixes**
  - Improved accuracy and clarity of API documentation for complex query parameters and responses.

- **Tests**
  - Introduced extensive new tests to verify Swagger response helpers and filter parameter generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->