### PR TITLE
feat(router): add server configuration support and update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.20.0
+	go.lumeweb.com/gswagger v0.20.2
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
 	go.lumeweb.com/portal-middleware v0.2.5
 	go.lumeweb.com/queryutil v0.3.2

--- a/route_builder_test.go
+++ b/route_builder_test.go
@@ -224,19 +224,16 @@ func TestNewRouter(t *testing.T) {
 			Version("1.0.0")
 
 		// Test with router configuration option
-		router, err := NewRouter(info, 
+		router, err := NewRouter(info,
 			WithRouterBasePath("/v1"),
 			WithRouterJSONDocsPath("/api/docs.json"),
 		)
 		assert.NoError(t, err)
 		assert.NotNil(t, router)
-		
-		// Verify options were applied
+
 		echoRouter := GetRouter(router)
 		require.NotNil(t, echoRouter, "router should not be nil")
-		
-		// Verify it's not nil and routes requests
-		
+
 		req := httptest.NewRequest("GET", "/v1/test", nil)
 		rr := httptest.NewRecorder()
 		echoRouter.ServeHTTP(rr, req)
@@ -247,5 +244,19 @@ func TestNewRouter(t *testing.T) {
 		// Empty API info should fail validation
 		_, err := NewRouter(APIInfo())
 		assert.Error(t, err)
+	})
+
+	t.Run("router with servers", func(t *testing.T) {
+		info := APIInfo().
+			Title("Test API").
+			Version("1.0.0")
+
+		router, err := NewRouter(info,
+			WithServer("https://api.example.com", "Production API"),
+			WithServer("https://staging-api.example.com", "Staging API"),
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, router)
+		assert.Len(t, router.GetSwaggerSchema().Servers, 3) // Includes default /api server
 	})
 }

--- a/router.go
+++ b/router.go
@@ -38,6 +38,7 @@ func GetRouter(r Router) *echo.Echo {
 	return nil
 }
 
+
 // GetGroup returns the underlying *echo.Group instance
 func GetGroup(r Router) *echo.Group {
 	router := r.Router().Router(true)
@@ -77,6 +78,11 @@ func NewSwaggerRouter(info APIInfoDefinition, opts ...RouterOption) (Router, err
 		EchoRouter: echo.New(),
 		OpenAPI: &openapi3.T{
 			Info: info.toOpenAPI(),
+			Servers: []*openapi3.Server{
+				{
+					URL: "/api",
+				},
+			},
 		},
 		Options: swagger.Options[echo.HandlerFunc, echo.MiddlewareFunc, es.Route]{
 			JSONDocumentationPath: SwaggerJSONPath,
@@ -162,6 +168,32 @@ func WithRouterBasePath(path string) RouterOption {
 func WithRouterOpenAPI(openapi *openapi3.T) RouterOption {
 	return func(c *RouterConfig) {
 		c.OpenAPI = openapi
+	}
+}
+
+// WithServer adds a server URL to the OpenAPI spec
+func WithServer(url string, description string) RouterOption {
+	return func(c *RouterConfig) {
+		if c.OpenAPI == nil {
+			return
+		}
+		if c.OpenAPI.Servers == nil {
+			c.OpenAPI.Servers = []*openapi3.Server{}
+		}
+		c.OpenAPI.Servers = append(c.OpenAPI.Servers, &openapi3.Server{
+			URL:         url,
+			Description: description,
+		})
+	}
+}
+
+// WithServers replaces all server URLs in the OpenAPI spec
+func WithServers(servers []*openapi3.Server) RouterOption {
+	return func(c *RouterConfig) {
+		if c.OpenAPI == nil {
+			return
+		}
+		c.OpenAPI.Servers = servers
 	}
 }
 


### PR DESCRIPTION
- Added support for configuring OpenAPI servers through new WithServer() and WithServers() RouterOptions
- Updated gswagger dependency from v0.20.0 to v0.20.2
- Added test cases for server configuration functionality
- Included default '/api' server in OpenAPI spec initialization
- Improved router test coverage with new server configuration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying custom OpenAPI server URLs in the router configuration, including options to add individual servers or replace the entire server list.
	- The default OpenAPI specification now includes a default server with URL "/api".

- **Tests**
	- Expanded test coverage to verify router creation with multiple server configurations. 

- **Chores**
	- Updated a dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->