### PR TITLE
feat(router): improve route initialization and swagger defaults

### DIFF
--- a/route_builder.go
+++ b/route_builder.go
@@ -3,6 +3,7 @@ package router
 import (
 	"github.com/labstack/echo/v4"
 	swagger "go.lumeweb.com/gswagger"
+	"net/http"
 )
 
 // AccessService defines the interface for route access control
@@ -39,6 +40,38 @@ func DefineOptions(opts ...RouteOption) []RouteOption {
 }
 
 // Core route builder
+// applyRouteOpts applies RouteOptions to a RouteDefinition
+func applyRouteOpts(d RouteDefinition, opts ...RouteOption) RouteDefinition {
+	// Make shallow copy
+	result := d
+
+	// Ensure maps are initialized if nil
+	if result.Swagger.Responses == nil {
+		result.Swagger.Responses = make(map[int]swagger.ContentValue)
+	}
+	if result.Swagger.PathParams == nil {
+		result.Swagger.PathParams = make(swagger.ParameterValue)
+	}
+	if result.Swagger.Querystring == nil {
+		result.Swagger.Querystring = make(swagger.ParameterValue)
+	}
+	if result.Swagger.Headers == nil {
+		result.Swagger.Headers = make(swagger.ParameterValue)
+	}
+	if result.Swagger.Cookies == nil {
+		result.Swagger.Cookies = make(swagger.ParameterValue)
+	}
+
+	// Apply route options
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&result)
+		}
+	}
+
+	return result
+}
+
 // NewRoute creates a new RouteDefinition with the given method, path and handler,
 // applying any provided RouteOptions.
 func NewRoute(method, path string, handler echo.HandlerFunc, opts ...RouteOption) RouteDefinition {
@@ -47,15 +80,35 @@ func NewRoute(method, path string, handler echo.HandlerFunc, opts ...RouteOption
 		Path:    path,
 		Handler: handler,
 		// Defaults
-		Access:  ACCESS_USER_ROLE,
-		Swagger: swagger.Definitions{},
+		Access: ACCESS_USER_ROLE,
+		Swagger: swagger.Definitions{
+			Responses: map[int]swagger.ContentValue{
+				http.StatusOK: defaultSuccessResponse(),
+				http.StatusBadRequest: swagger.ContentValue{
+					Description: "Bad Request",
+					Content: swagger.Content{
+						"application/json": swagger.Schema{
+							Value: map[string]string{
+								"error": "Bad Request",
+							},
+						},
+					},
+				},
+				http.StatusInternalServerError: swagger.ContentValue{
+					Description: "Internal Server Error",
+					Content: swagger.Content{
+						"application/json": swagger.Schema{
+							Value: map[string]string{
+								"error": "Internal Server Error",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
-	for _, opt := range opts {
-		opt(&def)
-	}
-
-	return def
+	return applyRouteOpts(def, opts...)
 }
 
 // Option setters

--- a/router.go
+++ b/router.go
@@ -38,7 +38,6 @@ func GetRouter(r Router) *echo.Echo {
 	return nil
 }
 
-
 // GetGroup returns the underlying *echo.Group instance
 func GetGroup(r Router) *echo.Group {
 	router := r.Router().Router(true)
@@ -261,7 +260,7 @@ func ListEndpointSwagger(
 
 	// Apply all options including the response option
 	allOpts := append([]SwaggerOption{responseOpt}, opts...)
-	def = applyOpts(def, "", allOpts)
+	def = applySwaggerOpts(def, "", allOpts)
 
 	return def
 }
@@ -307,13 +306,24 @@ func RegisterRoutes(
 	}
 
 	for _, route := range routes {
+		// Ensure route is properly initialized
+		finalRoute := applyRouteOpts(route)
+
 		// Register with router and swagger using route-specific middleware
+		// Ensure responses exist in swagger definitions
+		if finalRoute.Swagger.Responses == nil {
+			finalRoute.Swagger.Responses = make(map[int]swagger.ContentValue)
+		}
+		if len(finalRoute.Swagger.Responses) == 0 {
+			finalRoute.Swagger.Responses = DefaultPublicErrorResponses()
+		}
+
 		_, err := group.AddRoute(
-			route.Method,
-			route.Path,
-			route.Handler,
-			route.Swagger,
-			route.Middlewares...,
+			finalRoute.Method,
+			finalRoute.Path,
+			finalRoute.Handler,
+			finalRoute.Swagger,
+			finalRoute.Middlewares...,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to register route %s %s: %w", route.Method, route.Path, err)
@@ -419,7 +429,7 @@ func BasicSwagger(
 		}
 	}
 
-	return applyOpts(def, "", opts)
+	return applySwaggerOpts(def, "", opts)
 }
 
 // PaginatedResponseSwagger generates Swagger definitions for an endpoint

--- a/router_test.go
+++ b/router_test.go
@@ -30,6 +30,9 @@ func TestRegisterRoutes(t *testing.T) {
 					Path:    "/test",
 					Method:  "GET",
 					Handler: func(c echo.Context) error { return nil },
+					Swagger: swagger.Definitions{
+						Responses: DefaultPublicErrorResponses(),
+					},
 				},
 			},
 			wantRegisterErr:   false,

--- a/swagger.go
+++ b/swagger.go
@@ -127,23 +127,16 @@ func WithDescription(description string) SwaggerOption {
 // for a route. Automatically includes appropriate error responses based on access level.
 func WithSwagger(opts ...SwaggerOption) RouteOption {
 	return func(d *RouteDefinition) {
+		// Start with default error responses based on access level
 		def := swagger.Definitions{}
-
-		// Apply options with access context
-		for _, opt := range opts {
-			opt(&def, d.Access) // Pass access level
+		if d.Access == ACCESS_USER_ROLE || d.Access == ACCESS_ADMIN_ROLE {
+			def.Responses = DefaultAuthErrorResponses()
+		} else {
+			def.Responses = DefaultPublicErrorResponses()
 		}
 
-		// Set defaults if no responses configured
-		if def.Responses == nil {
-			if d.Access == ACCESS_USER_ROLE || d.Access == ACCESS_ADMIN_ROLE {
-				def.Responses = DefaultAuthErrorResponses()
-			} else {
-				def.Responses = DefaultPublicErrorResponses()
-			}
-		}
-
-		d.Swagger = def
+		// Apply user-provided options
+		d.Swagger = applySwaggerOpts(def, d.Access, opts)
 	}
 }
 
@@ -330,7 +323,7 @@ func DefineSwaggerErrorResponse(status int, errorMsg string) map[int]swagger.Con
 	return map[int]swagger.ContentValue{
 		status: {
 			Description: errorMsg,
-			Content: map[string]swagger.Schema{ // Corrected: Map value type is swagger.Schema
+			Content: swagger.Content{
 				"application/json": {
 					Value: ResponseError{Error: errorMsg},
 				},

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -1,14 +1,23 @@
 package router
 
 import (
+	"encoding/json"
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	swagger "go.lumeweb.com/gswagger"
 	"go.lumeweb.com/queryutil/filter"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+)
+
+const (
+	TypeArray   = openapi3.TypeArray
+	TypeObject  = openapi3.TypeObject
 )
 
 // Define a test schema that implements FieldSchema
@@ -31,6 +40,284 @@ func TestWithSwaggerOptions(t *testing.T) {
 	route := NewRoute("GET", "/test", handler, WithSwaggerOptions(WithSummary("Test Summary")))
 
 	assert.Equal(t, "Test Summary", route.Swagger.Summary)
+}
+
+func TestResponseSchemaGeneration(t *testing.T) {
+	type User struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}
+
+	tests := []struct {
+		name        string
+		status      int
+		description string
+		content     interface{}
+		wantSchema  map[string]interface{}
+	}{
+		{
+			name:        "simple object response",
+			status:      http.StatusOK,
+			description: "User details",
+			content:     User{},
+			wantSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"id":    map[string]interface{}{"type": "string"},
+					"name":  map[string]interface{}{"type": "string"},
+					"email": map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+		{
+			name:        "array response",
+			status:      http.StatusOK,
+			description: "User list",
+			content:     []User{},
+			wantSchema: map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"id":    map[string]interface{}{"type": "string"},
+						"name":  map[string]interface{}{"type": "string"},
+						"email": map[string]interface{}{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := NewRoute("GET", "/test", nil,
+				WithSwagger(
+					WithSuccessResponse(tt.status, tt.description,
+						WithJSONContent(tt.content),
+					),
+				),
+			)
+
+			// Verify the response schema was properly generated
+			resp := route.Swagger.Responses[tt.status]
+			assert.Equal(t, tt.description, resp.Description)
+
+			content := resp.Content["application/json"]
+			assert.NotNil(t, content)
+
+			// Generate the OpenAPI schema
+			router, err := NewRouter(APIInfo().
+				Title("Test API").
+				Version("1.0.0"))
+			require.NoError(t, err)
+
+			_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger)
+			require.NoError(t, err)
+
+			// Generate and resolve references
+			err = router.GenerateAndExposeOpenapi()
+			require.NoError(t, err)
+
+			// Get the generated OpenAPI spec
+			swaggerSchema := router.GetSwaggerSchema()
+			require.NotNil(t, swaggerSchema)
+
+			// Find our path in the schema
+			pathItem := swaggerSchema.Paths.Find("/test")
+			require.NotNil(t, pathItem)
+
+			operation := pathItem.GetOperation("GET")
+			require.NotNil(t, operation)
+
+			responseRef, exists := operation.Responses.Map()[strconv.Itoa(tt.status)]
+			require.True(t, exists, "expected response for status %d", tt.status)
+			require.NotNil(t, responseRef)
+
+			mediaType := responseRef.Value.Content.Get("application/json")
+			require.NotNil(t, mediaType, "expected application/json content for status %d", tt.status)
+
+			// Verify schema properties
+			schema := mediaType.Schema.Value
+			assert.NotNil(t, schema)
+
+			// Compare schema structure
+			if tt.wantSchema["type"] == "object" {
+				assert.True(t, schema.Type.Is(TypeObject))
+				assert.Equal(t, len(tt.wantSchema["properties"].(map[string]interface{})), len(schema.Properties))
+				for propName, propSchema := range tt.wantSchema["properties"].(map[string]interface{}) {
+					assert.Contains(t, schema.Properties, propName)
+					assert.True(t, schema.Properties[propName].Value.Type.Is(propSchema.(map[string]interface{})["type"].(string)))
+				}
+			} else if tt.wantSchema["type"] == "array" {
+				assert.True(t, schema.Type.Is(TypeArray))
+				items := schema.Items.Value
+				assert.NotNil(t, items)
+				assert.Equal(t, len(tt.wantSchema["items"].(map[string]interface{})["properties"].(map[string]interface{})), len(items.Properties))
+			}
+		})
+	}
+}
+
+func TestAPIKeyAuthEndpoint(t *testing.T) {
+	type Response struct {
+		Data string `json:"data"`
+	}
+
+	handler := func(c echo.Context) error {
+		return c.JSON(http.StatusOK, Response{Data: "test data"})
+	}
+
+	route := NewRoute("GET", "/secure/data", handler,
+		WithSwagger(
+			WithSummary("Get secure data"),
+			WithDescription("Requires API key authentication"),
+			WithHeaderParam("X-API-Key", "API key for authentication", "string"),
+			WithSuccessResponse(http.StatusOK, "Secure data retrieved",
+				WithJSONContent(Response{}),
+			),
+		),
+	)
+
+	// Test Swagger config
+	assert.Contains(t, route.Swagger.Headers, "X-API-Key")
+	assert.Equal(t, "string", route.Swagger.Headers["X-API-Key"].Schema.Value)
+
+	// Test actual response decoding
+	router, err := NewRouter(APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+
+	_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/secure/data", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Decode and verify response
+	var resp Response
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "test data", resp.Data)
+}
+
+func TestComplexRequestBodyEndpoint(t *testing.T) {
+	type OrderRequest struct {
+		Items    []string `json:"items"`
+		Priority int      `json:"priority"`
+		Notes    string   `json:"notes,omitempty"`
+	}
+
+	type OrderResponse struct {
+		OrderID string `json:"order_id"`
+	}
+
+	handler := func(c echo.Context) error {
+		var req OrderRequest
+		if err := c.Bind(&req); err != nil {
+			return err
+		}
+		return c.JSON(http.StatusCreated, OrderResponse{OrderID: "123"})
+	}
+
+	route := NewRoute("POST", "/orders", handler,
+		WithSwagger(
+			WithSummary("Create new order"),
+			WithRequestBody(OrderRequest{}, "Order details", true),
+			WithSuccessResponse(http.StatusCreated, "Order created",
+				WithJSONContent(OrderResponse{}),
+			),
+		),
+	)
+
+	// Test Swagger config
+	assert.True(t, route.Swagger.RequestBody.Required)
+	assert.Contains(t, route.Swagger.RequestBody.Content, "application/json")
+
+	// Test actual request/response flow
+	router, err := NewRouter(APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+
+	_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger)
+	require.NoError(t, err)
+
+	reqBody := `{"items":["item1","item2"],"priority":1}`
+	req := httptest.NewRequest("POST", "/orders", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusCreated, rr.Code)
+
+	// Decode and verify response
+	var resp OrderResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "123", resp.OrderID)
+}
+
+func TestDeprecatedEndpoint(t *testing.T) {
+	type Response struct {
+		Message string `json:"message"`
+	}
+
+	handler := func(c echo.Context) error {
+		c.Response().Header().Set("Deprecation", "true")
+		c.Response().Header().Set("Sunset", "2025-12-31")
+		return c.JSON(http.StatusOK, Response{Message: "Deprecated"})
+	}
+
+	route := NewRoute("GET", "/old-endpoint", handler,
+		WithSwagger(
+			WithSummary("Deprecated endpoint"),
+			WithDescription("This endpoint is deprecated and will be removed"),
+			WithResponseHeaders(http.StatusOK, "Success but deprecated",
+				map[string]swagger.Schema{
+					"application/json": {
+						Value: Response{},
+					},
+				},
+				map[string]string{
+					"Deprecation": "true",
+					"Sunset":      "2025-12-31",
+				},
+			),
+		),
+	)
+
+	// Test Swagger config
+	resp := route.Swagger.Responses[http.StatusOK]
+	assert.Contains(t, resp.Headers, "Deprecation")
+	assert.Contains(t, resp.Headers, "Sunset")
+
+	// Test actual response
+	router, err := NewRouter(APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+
+	_, err = router.AddRoute(route.Method, route.Path, route.Handler, route.Swagger)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/old-endpoint", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "true", rr.Header().Get("Deprecation"))
+	assert.Equal(t, "2025-12-31", rr.Header().Get("Sunset"))
+
+	// Decode and verify response
+	var respBody Response
+	err = json.NewDecoder(rr.Body).Decode(&respBody)
+	require.NoError(t, err)
+	assert.Equal(t, "Deprecated", respBody.Message)
 }
 
 func TestWithFilterParamsFromSchema(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -17,39 +17,120 @@ func baseDefinition() swagger.Definitions {
 		Cookies:     make(swagger.ParameterValue),
 	}
 	def.Responses = map[int]swagger.ContentValue{
-		http.StatusOK: {
-			Description: "Success",
-			Content:     nil, // Response body will be defined by the route
-		},
-		http.StatusUnprocessableEntity: {
-			Description: "Validation Failed",
-			Content: swagger.Content{
-				"application/json": {
-					Value: map[string]any{
-						"error":  "validation failed",
-						"fields": map[string]string{},
-					},
-				},
-			},
-		},
-		http.StatusInternalServerError: {
-			Description: "Internal Server Error",
-			Content: swagger.Content{
-				"application/json": {
-					Value: map[string]string{
-						"error": "Internal Server Error",
-					},
-				},
-			},
-		},
+		http.StatusOK:                  defaultSuccessResponse(),
+		http.StatusBadRequest:          badRequestResponse(),
+		http.StatusUnauthorized:        unauthorizedResponse(),
+		http.StatusForbidden:           forbiddenResponse(),
+		http.StatusNotFound:            notFoundResponse(),
+		http.StatusUnprocessableEntity: validationFailedResponse(),
+		http.StatusInternalServerError: internalServerErrorResponse(),
 	}
 	return def
 }
 
-// Helper to apply options to any definition
-// applyOpts applies a set of SwaggerOptions to a swagger.Definitions,
-// returning the modified definitions.
-func applyOpts(d swagger.Definitions, access string, opts []SwaggerOption) swagger.Definitions {
+// defaultSuccessResponse returns the standard success response structure
+func defaultSuccessResponse() swagger.ContentValue {
+	return swagger.ContentValue{
+		Description: "Success",
+		Content: swagger.Content{
+			"application/json": {
+				Value: map[string]string{
+					"status": "success",
+				},
+			},
+		},
+	}
+}
+
+// badRequestResponse returns the standard 400 Bad Request response
+func badRequestResponse() swagger.ContentValue {
+	return swagger.ContentValue{
+		Description: "Bad Request",
+		Content: swagger.Content{
+			"application/json": {
+				Value: map[string]string{
+					"error": "Bad Request",
+				},
+			},
+		},
+	}
+}
+
+// unauthorizedResponse returns the standard 401 Unauthorized response
+func unauthorizedResponse() swagger.ContentValue {
+	return swagger.ContentValue{
+		Description: "Unauthorized",
+		Content: swagger.Content{
+			"application/json": {
+				Value: map[string]string{
+					"error": "Unauthorized",
+				},
+			},
+		},
+	}
+}
+
+// forbiddenResponse returns the standard 403 Forbidden response
+func forbiddenResponse() swagger.ContentValue {
+	return swagger.ContentValue{
+		Description: "Forbidden",
+		Content: swagger.Content{
+			"application/json": {
+				Value: map[string]string{
+					"error": "Forbidden",
+				},
+			},
+		},
+	}
+}
+
+// notFoundResponse returns the standard 404 Not Found response
+func notFoundResponse() swagger.ContentValue {
+	return swagger.ContentValue{
+		Description: "Not Found",
+		Content: swagger.Content{
+			"application/json": {
+				Value: map[string]string{
+					"error": "Not Found",
+				},
+			},
+		},
+	}
+}
+
+// validationFailedResponse returns the standard 422 Unprocessable Entity response
+func validationFailedResponse() swagger.ContentValue {
+	return swagger.ContentValue{
+		Description: "Validation Failed",
+		Content: swagger.Content{
+			"application/json": {
+				Value: map[string]any{
+					"error":  "validation failed",
+					"fields": map[string]string{},
+				},
+			},
+		},
+	}
+}
+
+// internalServerErrorResponse returns the standard 500 Internal Server Error response
+func internalServerErrorResponse() swagger.ContentValue {
+	return swagger.ContentValue{
+		Description: "Internal Server Error",
+		Content: swagger.Content{
+			"application/json": {
+				Value: map[string]string{
+					"error": "Internal Server Error",
+				},
+			},
+		},
+	}
+}
+
+// applySwaggerOpts applies a set of SwaggerOptions to a swagger.Definitions,
+// returning the modified definitions. This is the centralized place for applying
+// Swagger-specific options.
+func applySwaggerOpts(d swagger.Definitions, access string, opts []SwaggerOption) swagger.Definitions {
 	// Make shallow copy of the definition
 	result := d
 


### PR DESCRIPTION
- Add applyRouteOpts helper to consolidate route option application logic
- Set default success and error responses in NewRoute
- Ensure proper initialization of swagger parameter maps
- Fix swagger.Content type in DefineSwaggerErrorResponse
- Add comprehensive response helper functions (defaultSuccessResponse, badRequestResponse, etc)
- Rename applyOpts to applySwaggerOpts for clarity
- Update tests to verify new behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved default HTTP response definitions for all routes, including standardized success and error responses in API documentation.
- **Bug Fixes**
	- Ensured all Swagger response maps are properly initialized to prevent potential errors.
- **Refactor**
	- Centralized and streamlined the application of route and Swagger options for more consistent route initialization.
- **Tests**
	- Added comprehensive tests for OpenAPI schema generation, endpoint authentication, request/response handling, and deprecation headers in API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->