### PR TITLE
refactor(router): improve response handling and merging logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.20.3
+	go.lumeweb.com/gswagger v0.20.4
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
 	go.lumeweb.com/portal-middleware v0.2.5
 	go.lumeweb.com/queryutil v0.3.2

--- a/route_builder.go
+++ b/route_builder.go
@@ -39,13 +39,12 @@ func DefineOptions(opts ...RouteOption) []RouteOption {
 	return opts
 }
 
-// Core route builder
-// applyRouteOpts applies RouteOptions to a RouteDefinition
+// applyRouteOpts applies RouteOptions to a RouteDefinition and ensures proper initialization
 func applyRouteOpts(d RouteDefinition, opts ...RouteOption) RouteDefinition {
 	// Make shallow copy
 	result := d
 
-	// Ensure maps are initialized if nil
+	// Initialize maps if nil
 	if result.Swagger.Responses == nil {
 		result.Swagger.Responses = make(map[int]swagger.ContentValue)
 	}
@@ -69,6 +68,14 @@ func applyRouteOpts(d RouteDefinition, opts ...RouteOption) RouteDefinition {
 		}
 	}
 
+	// Ensure we have at least the default success response, preserving existing ones
+	result.Swagger.Responses = MergeResponses(
+		result.Swagger.Responses,
+		map[int]swagger.ContentValue{
+			http.StatusOK: defaultSuccessResponse(),
+		},
+	)
+
 	return result
 }
 
@@ -82,29 +89,14 @@ func NewRoute(method, path string, handler echo.HandlerFunc, opts ...RouteOption
 		// Defaults
 		Access: ACCESS_USER_ROLE,
 		Swagger: swagger.Definitions{
-			Responses: map[int]swagger.ContentValue{
-				http.StatusOK: defaultSuccessResponse(),
-				http.StatusBadRequest: swagger.ContentValue{
-					Description: "Bad Request",
-					Content: swagger.Content{
-						"application/json": swagger.Schema{
-							Value: map[string]string{
-								"error": "Bad Request",
-							},
-						},
-					},
+			Responses: DefineSwaggerErrorResponses(
+				map[int]swagger.ContentValue{
+					http.StatusOK: defaultSuccessResponse(),
+					http.StatusBadRequest: badRequestResponse(),
+					http.StatusInternalServerError: internalServerErrorResponse(),
 				},
-				http.StatusInternalServerError: swagger.ContentValue{
-					Description: "Internal Server Error",
-					Content: swagger.Content{
-						"application/json": swagger.Schema{
-							Value: map[string]string{
-								"error": "Internal Server Error",
-							},
-						},
-					},
-				},
-			},
+				DefaultCoreErrorResponses(),
+			),
 		},
 	}
 

--- a/router.go
+++ b/router.go
@@ -285,8 +285,11 @@ type RouteDefinition struct {
 }
 
 // RegisterRoutes registers a slice of RouteDefinitions with the provided Router.
-// It registers routes with both the router and swagger documentation.
-// It also registers access control for protected routes if an access service is provided.
+// It handles:
+// - Applying common middleware
+// - Initializing route definitions
+// - Registering routes with the router
+// - Setting up access control
 func RegisterRoutes(
 	gRouter Router,
 	accessSvc AccessService,
@@ -306,18 +309,10 @@ func RegisterRoutes(
 	}
 
 	for _, route := range routes {
-		// Ensure route is properly initialized
+		// Apply all route options and ensure proper initialization
 		finalRoute := applyRouteOpts(route)
 
-		// Register with router and swagger using route-specific middleware
-		// Ensure responses exist in swagger definitions
-		if finalRoute.Swagger.Responses == nil {
-			finalRoute.Swagger.Responses = make(map[int]swagger.ContentValue)
-		}
-		if len(finalRoute.Swagger.Responses) == 0 {
-			finalRoute.Swagger.Responses = DefaultPublicErrorResponses()
-		}
-
+		// Register route with router
 		_, err := group.AddRoute(
 			finalRoute.Method,
 			finalRoute.Path,
@@ -329,10 +324,10 @@ func RegisterRoutes(
 			return fmt.Errorf("failed to register route %s %s: %w", route.Method, route.Path, err)
 		}
 
-		// Register access control
-		if route.Access != "" && accessSvc != nil {
-			if err := accessSvc.RegisterRoute(subdomain, route.Path, route.Method, route.Access); err != nil {
-				return fmt.Errorf("failed to register access for route %s: %w", route.Path, err)
+		// Register access control if needed
+		if finalRoute.Access != "" && accessSvc != nil {
+			if err := accessSvc.RegisterRoute(subdomain, finalRoute.Path, finalRoute.Method, finalRoute.Access); err != nil {
+				return fmt.Errorf("failed to register access for route %s: %w", finalRoute.Path, err)
 			}
 		}
 	}
@@ -391,13 +386,16 @@ func AuthSwagger(
 		Content:     swagger.Content{"application/json": {Value: map[string]string{"error": "Forbidden"}}},
 	}
 
-	// Merge with error responses
-	for code, body := range errResp {
-		def.Responses[code] = swagger.ContentValue{
-			Description: http.StatusText(code),
-			Content:     swagger.Content{"application/json": {Value: body}},
-		}
-	}
+	convertedErrors := convertErrorResponses(errResp)
+
+	// Merge with error responses while preserving defaults
+	def.Responses = MergeResponses(
+		def.Responses,
+		convertedErrors,
+		map[int]swagger.ContentValue{
+			http.StatusOK: defaultSuccessResponse(),
+		},
+	)
 
 	return def
 }
@@ -421,13 +419,27 @@ func BasicSwagger(
 	def.Description = description
 	def.Tags = []string{"Public"}
 
-	// Merge error responses
+	// Convert map[int]any to map[int]swagger.ContentValue
+	convertedErrors := make(map[int]swagger.ContentValue)
 	for code, body := range errResp {
-		def.Responses[code] = swagger.ContentValue{
+		convertedErrors[code] = swagger.ContentValue{
 			Description: http.StatusText(code),
-			Content:     swagger.Content{"application/json": {Value: body}},
+			Content: swagger.Content{
+				"application/json": {
+					Value: body,
+				},
+			},
 		}
 	}
+
+	// Merge with error responses while preserving defaults
+	def.Responses = MergeResponses(
+		def.Responses,
+		convertedErrors,
+		map[int]swagger.ContentValue{
+			http.StatusOK: defaultSuccessResponse(),
+		},
+	)
 
 	return applySwaggerOpts(def, "", opts)
 }

--- a/swagger.go
+++ b/swagger.go
@@ -125,18 +125,29 @@ func WithDescription(description string) SwaggerOption {
 
 // WithSwagger creates a RouteOption that sets the Swagger documentation definitions
 // for a route. Automatically includes appropriate error responses based on access level.
+// Preserves any existing success responses (2xx status codes) and allows custom
+// success responses from options to be merged.
 func WithSwagger(opts ...SwaggerOption) RouteOption {
 	return func(d *RouteDefinition) {
-		// Start with default error responses based on access level
-		def := swagger.Definitions{}
+		// Get default error responses based on access level
+		var defaultErrors map[int]swagger.ContentValue
 		if d.Access == ACCESS_USER_ROLE || d.Access == ACCESS_ADMIN_ROLE {
-			def.Responses = DefaultAuthErrorResponses()
+			defaultErrors = DefaultAuthErrorResponses()
 		} else {
-			def.Responses = DefaultPublicErrorResponses()
+			defaultErrors = DefaultPublicErrorResponses()
 		}
 
-		// Apply user-provided options
-		d.Swagger = applySwaggerOpts(def, d.Access, opts)
+		// Initialize responses if nil
+		if d.Swagger.Responses == nil {
+			d.Swagger.Responses = make(map[int]swagger.ContentValue)
+		}
+
+		// Merge default error responses into existing responses, preserving existing success responses
+		d.Swagger.Responses = MergeResponses(d.Swagger.Responses, defaultErrors)
+
+		// Apply user-provided options directly to d.Swagger
+		// This allows options like WithSuccessResponse to add/modify responses
+		d.Swagger = applySwaggerOpts(d.Swagger, d.Access, opts)
 	}
 }
 
@@ -296,15 +307,20 @@ func DefineResponse(status int, description string, opts ...ResponseOption) map[
 	}
 }
 
-// WithSuccessResponse creates a SwaggerOption that adds a success response
+// WithSuccessResponse creates a SwaggerOption that adds a success response while preserving existing responses.
+// The success response will not overwrite any existing response for the same status code.
 func WithSuccessResponse(status int, description string, opts ...ResponseOption) SwaggerOption {
 	return func(d *swagger.Definitions, accessRole string) {
+		// Initialize responses if nil
 		if d.Responses == nil {
 			d.Responses = make(map[int]swagger.ContentValue)
 		}
-		for code, resp := range DefineResponse(status, description, opts...) {
-			d.Responses[code] = resp
-		}
+
+		// Create the new success response
+		newResponse := DefineResponse(status, description, opts...)
+		
+		// Merge with existing responses, allowing our new response to override existing ones
+		d.Responses = MergeResponses(newResponse, d.Responses)
 	}
 }
 
@@ -332,15 +348,34 @@ func DefineSwaggerErrorResponse(status int, errorMsg string) map[int]swagger.Con
 	}
 }
 
-// DefineSwaggerErrorResponses combines multiple error responses for Swagger docs.
-func DefineSwaggerErrorResponses(responses ...map[int]swagger.ContentValue) map[int]swagger.ContentValue {
+// MergeResponses combines multiple response maps while preserving success responses (2xx).
+// Later responses override earlier ones for the same status code, except success responses
+// which are preserved from their first occurrence.
+func MergeResponses(responses ...map[int]swagger.ContentValue) map[int]swagger.ContentValue {
 	combined := make(map[int]swagger.ContentValue)
-	for _, r := range responses {
-		for code, resp := range r {
-			combined[code] = resp
+
+	// Process responses in order, preserving the first success response encountered
+	for _, responseMap := range responses {
+		for code, resp := range responseMap {
+			// If it's a success response (2xx) and we don't have one for this code yet, add it.
+			if code >= 200 && code < 300 {
+				if _, exists := combined[code]; !exists {
+					combined[code] = resp
+				}
+			} else {
+				// If it's an error response or a non-2xx success code, always add/override.
+				combined[code] = resp
+			}
 		}
 	}
+
 	return combined
+}
+
+// DefineSwaggerErrorResponses combines multiple error responses for Swagger docs.
+// Preserves existing success responses (2xx) when merging.
+func DefineSwaggerErrorResponses(responses ...map[int]swagger.ContentValue) map[int]swagger.ContentValue {
+	return MergeResponses(responses...)
 }
 
 // DefaultCoreErrorResponses returns a map containing core HTTP error responses shared by all routes (400, 404, 500).
@@ -487,6 +522,22 @@ func WithFilterParamsFromSchema(schema FieldSchema) SwaggerOption {
 }
 
 // opIsMultiValue checks if an operator expects multiple values
+// convertErrorResponses converts a map of error responses from map[int]any to map[int]swagger.ContentValue
+func convertErrorResponses(errResp map[int]any) map[int]swagger.ContentValue {
+	converted := make(map[int]swagger.ContentValue)
+	for code, body := range errResp {
+		converted[code] = swagger.ContentValue{
+			Description: http.StatusText(code),
+			Content: swagger.Content{
+				"application/json": {
+					Value: body,
+				},
+			},
+		}
+	}
+	return converted
+}
+
 func opIsMultiValue(op filter.Operator) bool {
 	return op == filter.OpIn || op == filter.OpNin ||
 		op == filter.OpIna || op == filter.OpNina ||
@@ -550,16 +601,32 @@ func WithListEndpoint(
 }
 
 // WithErrorResponses creates a SwaggerOption that merges custom error responses with
-// default responses based on access level (same behavior as WithCustomErrorResponses)
-func WithErrorResponses(errors map[int]swagger.ContentValue) SwaggerOption {
+// default responses based on access level while preserving existing success responses.
+// The merging follows these rules:
+// 1. Existing success responses (2xx) are preserved
+// 2. Default error responses are added if not already present
+// 3. Custom error responses override defaults
+func WithErrorResponses(customErrors map[int]swagger.ContentValue) SwaggerOption {
 	return func(d *swagger.Definitions, accessRole string) {
-		var defaultResponses map[int]swagger.ContentValue
+		// Get default error responses based on access level
+		var defaultErrors map[int]swagger.ContentValue
 		if accessRole == ACCESS_USER_ROLE || accessRole == ACCESS_ADMIN_ROLE {
-			defaultResponses = DefaultAuthErrorResponses()
+			defaultErrors = DefaultAuthErrorResponses()
 		} else {
-			defaultResponses = DefaultPublicErrorResponses()
+			defaultErrors = DefaultPublicErrorResponses()
 		}
 
-		d.Responses = DefineSwaggerErrorResponses(defaultResponses, errors)
+		// Initialize responses if nil
+		if d.Responses == nil {
+			d.Responses = make(map[int]swagger.ContentValue)
+		}
+
+		// Merge in order: defaults -> custom errors.
+		// Existing success responses in d.Responses are preserved by MergeResponses.
+		d.Responses = MergeResponses(
+			d.Responses, // Start with existing responses (preserves existing success)
+			defaultErrors,
+			customErrors,
+		)
 	}
 }

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -658,6 +658,95 @@ func TestDefineSwaggerErrorResponse(t *testing.T) {
 	}
 }
 
+func TestMergeResponses(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []map[int]swagger.ContentValue
+		expected map[int]swagger.ContentValue
+	}{
+		{
+			name: "empty inputs",
+			input: []map[int]swagger.ContentValue{
+				{},
+				{},
+			},
+			expected: map[int]swagger.ContentValue{},
+		},
+		{
+			name: "merge success responses",
+			input: []map[int]swagger.ContentValue{
+				{
+					200: {Description: "Success A"},
+					400: {Description: "Error A"},
+				},
+				{
+					201: {Description: "Success B"},
+					401: {Description: "Error B"},
+				},
+			},
+			expected: map[int]swagger.ContentValue{
+				200: {Description: "Success A"},
+				201: {Description: "Success B"},
+				400: {Description: "Error A"},
+				401: {Description: "Error B"},
+			},
+		},
+		{
+			name: "preserve first success response",
+			input: []map[int]swagger.ContentValue{
+				{
+					200: {Description: "First Success"},
+				},
+				{
+					200: {Description: "Second Success"},
+				},
+			},
+			expected: map[int]swagger.ContentValue{
+				200: {Description: "First Success"},
+			},
+		},
+		{
+			name: "override error responses",
+			input: []map[int]swagger.ContentValue{
+				{
+					400: {Description: "First Error"},
+				},
+				{
+					400: {Description: "Second Error"},
+				},
+			},
+			expected: map[int]swagger.ContentValue{
+				400: {Description: "Second Error"},
+			},
+		},
+		{
+			name: "mixed success and error responses",
+			input: []map[int]swagger.ContentValue{
+				{
+					200: {Description: "Success"},
+					400: {Description: "First Error"},
+				},
+				{
+					201: {Description: "New Success"},
+					400: {Description: "New Error"},
+				},
+			},
+			expected: map[int]swagger.ContentValue{
+				200: {Description: "Success"},
+				201: {Description: "New Success"},
+				400: {Description: "New Error"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeResponses(tt.input...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestDefaultCoreErrorResponses(t *testing.T) {
 	core := DefaultCoreErrorResponses()
 
@@ -738,7 +827,7 @@ func TestWithErrorResponses(t *testing.T) {
 					},
 				},
 			},
-			expectedCodes: []int{400, 404, 500, 422, 429},
+			expectedCodes: []int{200, 400, 404, 422, 429, 500},
 		},
 		{
 			name:       "auth route with string errors",
@@ -761,7 +850,7 @@ func TestWithErrorResponses(t *testing.T) {
 					},
 				},
 			},
-			expectedCodes: []int{400, 401, 403, 404, 500, 409, 503},
+			expectedCodes: []int{200, 400, 401, 403, 404, 409, 500, 503},
 		},
 	}
 
@@ -773,6 +862,125 @@ func TestWithErrorResponses(t *testing.T) {
 			assert.Len(t, route.Swagger.Responses, len(tt.expectedCodes))
 			for _, code := range tt.expectedCodes {
 				assert.Contains(t, route.Swagger.Responses, code)
+			}
+		})
+	}
+}
+
+func TestSuccessResponsePreservation(t *testing.T) {
+	tests := []struct {
+		name         string
+		successCode  int
+		errorCode    int
+		successFirst bool
+	}{
+		{
+			name:         "success before errors",
+			successCode:  200,
+			errorCode:    400,
+			successFirst: true,
+		},
+		{
+			name:         "success after errors",
+			successCode:  201,
+			errorCode:    500,
+			successFirst: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create route with success response
+			route := NewRoute("GET", "/test", nil)
+			
+			// Apply options in specified order
+			if tt.successFirst {
+				WithSuccessResponse(tt.successCode, "Success", WithJSONContent("success"))(&route.Swagger, "")
+				WithErrorResponses(map[int]swagger.ContentValue{
+					tt.errorCode: {
+						Description: "Error",
+						Content: map[string]swagger.Schema{
+							"application/json": {
+								Value: ResponseError{Error: "Error"},
+							},
+						},
+					},
+				})(&route.Swagger, "")
+			} else {
+				WithErrorResponses(map[int]swagger.ContentValue{
+					tt.errorCode: {
+						Description: "Error",
+						Content: map[string]swagger.Schema{
+							"application/json": {
+								Value: ResponseError{Error: "Error"},
+							},
+						},
+					},
+				})(&route.Swagger, "")
+				WithSuccessResponse(tt.successCode, "Success", WithJSONContent("success"))(&route.Swagger, "")
+			}
+
+			// Verify both responses exist
+			assert.Contains(t, route.Swagger.Responses, tt.successCode)
+			assert.Contains(t, route.Swagger.Responses, tt.errorCode)
+			
+			// Verify success response wasn't overwritten
+			successResp := route.Swagger.Responses[tt.successCode]
+			assert.Equal(t, "Success", successResp.Description)
+			// Handle both string and default success response formats
+			switch v := successResp.Content["application/json"].Value.(type) {
+			case string:
+				assert.Equal(t, "success", v)
+			case map[string]string:
+				assert.Equal(t, "success", v["status"])
+			default:
+				t.Errorf("unexpected success response type: %T", v)
+			}
+		})
+	}
+}
+
+func TestDefaultResponsesNotOverwritingSuccess(t *testing.T) {
+	tests := []struct {
+		name        string
+		accessRole  string
+		successCode int
+	}{
+		{
+			name:        "public route",
+			accessRole:  "",
+			successCode: 200,
+		},
+		{
+			name:        "auth route", 
+			accessRole:  ACCESS_USER_ROLE,
+			successCode: 201,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := NewRoute("GET", "/test", nil, WithAccess(tt.accessRole))
+			
+			// Add success response first
+			WithSuccessResponse(tt.successCode, "Success", WithJSONContent("success"))(&route.Swagger, tt.accessRole)
+			
+			// Then add default error responses via WithSwagger
+			WithSwagger()(&route)
+
+			// Verify success response still exists
+			assert.Contains(t, route.Swagger.Responses, tt.successCode)
+			successResp := route.Swagger.Responses[tt.successCode]
+			assert.Equal(t, "Success", successResp.Description)
+			assert.Equal(t, "success", successResp.Content["application/json"].Value)
+
+			// Verify default error responses were added
+			if tt.accessRole == "" {
+				assert.Contains(t, route.Swagger.Responses, http.StatusBadRequest)
+				assert.Contains(t, route.Swagger.Responses, http.StatusNotFound)
+			} else {
+				assert.Contains(t, route.Swagger.Responses, http.StatusUnauthorized)
+				assert.Contains(t, route.Swagger.Responses, http.StatusForbidden)
 			}
 		})
 	}


### PR DESCRIPTION
- Update gswagger dependency to v0.20.4
- Refactor response merging to preserve success responses (2xx)
- Ensure default success response is always included
- Improve error response handling and conversion
- Add comprehensive tests for response merging behavior
- Clean up route initialization and documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of API response documentation to ensure success responses are consistently preserved and not overwritten by error responses in Swagger definitions.
- **Refactor**
	- Standardized and centralized error response definitions for API documentation, resulting in more consistent and maintainable Swagger output.
	- Streamlined route registration and access control setup for improved consistency.
- **Tests**
	- Added new tests to verify correct merging and preservation of success and error responses in API documentation.
- **Chores**
	- Updated a dependency to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->