### PR TITLE
feat(router): add reflector options configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.20.4
+	go.lumeweb.com/gswagger v0.20.5
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
 	go.lumeweb.com/portal-middleware v0.2.5
 	go.lumeweb.com/queryutil v0.3.2

--- a/router.go
+++ b/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"fmt"
+	"github.com/invopop/jsonschema"
 	"go.lumeweb.com/gswagger/apirouter"
 	"net/http"
 	"strings"
@@ -103,6 +104,9 @@ func NewSwaggerRouter(info APIInfoDefinition, opts ...RouterOption) (Router, err
 	if config.OpenAPI != nil {
 		options.Openapi = config.OpenAPI
 	}
+	if config.ReflectorOptions != nil {
+		options.ReflectorOptions = config.ReflectorOptions
+	}
 
 	router, err := swagger.NewRouter(
 		es.NewRouter(config.EchoRouter),
@@ -126,10 +130,11 @@ func UpdateRouterInfo(r Router, info APIInfoDefinition) {
 
 // RouterConfig holds configuration for router initialization
 type RouterConfig struct {
-	EchoRouter *echo.Echo
-	OpenAPI    *openapi3.T
-	Options    swagger.Options[echo.HandlerFunc, echo.MiddlewareFunc, es.Route]
-	PathPrefix string
+	EchoRouter       *echo.Echo
+	OpenAPI          *openapi3.T
+	Options          swagger.Options[echo.HandlerFunc, echo.MiddlewareFunc, es.Route]
+	PathPrefix       string
+	ReflectorOptions *jsonschema.Reflector
 }
 
 // RouterOption defines a function type for configuring router initialization.
@@ -167,6 +172,14 @@ func WithRouterBasePath(path string) RouterOption {
 func WithRouterOpenAPI(openapi *openapi3.T) RouterOption {
 	return func(c *RouterConfig) {
 		c.OpenAPI = openapi
+	}
+}
+
+// WithReflectorOptions configures the jsonschema reflector options
+// used for schema generation.
+func WithReflectorOptions(opts *jsonschema.Reflector) RouterOption {
+	return func(c *RouterConfig) {
+		c.ReflectorOptions = opts
 	}
 }
 


### PR DESCRIPTION
- Update go.mod to use gswagger v0.20.5
- Add jsonschema reflector options support in router configuration
- Add new WithReflectorOptions function to configure schema generation options
- Pass reflector options to swagger.NewRouter