### PR TITLE
feat(static): add MPA support and improve static file handling

### DIFF
--- a/static_helpers.go
+++ b/static_helpers.go
@@ -3,6 +3,7 @@ package router
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"os"
@@ -17,7 +18,7 @@ import (
 // header when a 200 OK response is written
 type cacheControlWriter struct {
 	http.ResponseWriter
-	cacheControl string
+	cacheControl  string
 	headerWritten bool
 }
 
@@ -39,10 +40,13 @@ func (w *cacheControlWriter) Write(b []byte) (int, error) {
 const (
 	// StaticAssetsPath is the URL path prefix for static assets
 	StaticAssetsPath = "/static"
-	// StaticAssetsDir is the directory name where static assets are stored
-	StaticAssetsDir = "static"
 	// DefaultIndexFile is the default filename to serve for SPA fallback
 	DefaultIndexFile = "index.html"
+)
+
+var (
+	// StaticAssetsDir is the directory name where static assets are stored (derived from StaticAssetsPath)
+	StaticAssetsDir = strings.TrimPrefix(StaticAssetsPath, "/")
 	// FaviconFiles lists the supported favicon file extensions
 	FaviconFiles = "ico,png,svg,gif"
 )
@@ -60,6 +64,18 @@ type httpToFS struct {
 // Implements fs.FS interface.
 func (h httpToFS) Open(name string) (fs.File, error) {
 	return h.fs.Open(name)
+}
+
+// getAssetsSubFS tries to get a sub-filesystem for the assets directory if it exists.
+// Falls back to the original filesystem if the assets directory doesn't exist.
+func getAssetsSubFS(fsys fs.FS, assetsDir string) fs.FS {
+	staticFS := fsys
+	if _, err := fs.Stat(fsys, assetsDir); err == nil {
+		if subFs, err := fs.Sub(fsys, assetsDir); err == nil {
+			staticFS = subFs
+		}
+	}
+	return staticFS
 }
 
 // fsAdapter converts between filesystem interfaces.
@@ -96,6 +112,7 @@ func StaticConfigWithFS(fsys any) StaticConfig {
 	return StaticConfig{
 		FS:        fsAdapter(fsys),
 		IndexFile: DefaultIndexFile,
+		AssetsDir: StaticAssetsDir,
 	}
 }
 
@@ -110,13 +127,15 @@ func StaticConfigFromEnv(envVar string) StaticConfig {
 	return StaticConfig{
 		FS:        os.DirFS(path),
 		IndexFile: DefaultIndexFile,
+		AssetsDir: StaticAssetsDir,
 	}
 }
 
 // PublicFilesConfig returns a StaticConfig for serving public files from disk
 func PublicFilesConfig(dirPath string) StaticConfig {
 	return StaticConfig{
-		DirPath: dirPath,
+		DirPath:   dirPath,
+		AssetsDir: StaticAssetsDir,
 	}
 }
 
@@ -124,8 +143,9 @@ func PublicFilesConfig(dirPath string) StaticConfig {
 func PublicFilesEnvConfig(envVar string) StaticConfig {
 	path := os.Getenv(envVar)
 	return StaticConfig{
-		DirPath: path,
-		EnvVar:  envVar,
+		DirPath:   path,
+		EnvVar:    envVar,
+		AssetsDir: StaticAssetsDir,
 	}
 }
 
@@ -169,6 +189,43 @@ func MustDefaultPublicFilesEnvSetup(r Router, envVar string) {
 	MustSetupStaticRoutes(r, PublicFilesEnvConfig(envVar))
 }
 
+// MPASetup is a shorthand helper to configure Multi-Page Application support
+// with the given filesystem. The fsys parameter can be either:
+// - fs.FS (for embedded files)
+// - http.FileSystem (for directory-based files)
+func MPASetup(r Router, fsys any) error {
+	return SetupStaticRoutes(r, StaticConfig{
+		FS:  fsAdapter(fsys),
+		MPA: true,
+	})
+}
+
+// MPASetupWithAssets is a shorthand helper to configure Multi-Page Application support
+// with the given filesystem and custom assets directory. The fsys parameter can be either:
+// - fs.FS (for embedded files)
+// - http.FileSystem (for directory-based files)
+func MPASetupWithAssets(r Router, fsys any, assetsDir string) error {
+	return SetupStaticRoutes(r, StaticConfig{
+		FS:        fsAdapter(fsys),
+		MPA:       true,
+		AssetsDir: assetsDir,
+	})
+}
+
+// MustMPASetup is a panic-on-error version of MPASetup
+func MustMPASetup(r Router, fsys any) {
+	if err := MPASetup(r, fsys); err != nil {
+		panic(fmt.Sprintf("Failed to setup MPA routes: %v", err))
+	}
+}
+
+// MustMPASetupWithAssets is a panic-on-error version of MPASetupWithAssets
+func MustMPASetupWithAssets(r Router, fsys any, assetsDir string) {
+	if err := MPASetupWithAssets(r, fsys, assetsDir); err != nil {
+		panic(fmt.Sprintf("Failed to setup MPA routes with assets dir %s: %v", assetsDir, err))
+	}
+}
+
 // StaticConfig defines configuration options for serving static files.
 // Only one of these fields should be set:
 // - DirPath or EnvVar for directory-based serving
@@ -183,17 +240,24 @@ type StaticConfig struct {
 	// Only used if DirPath is empty.
 	EnvVar string
 
+	// AssetsDir specifies the directory name where static assets are stored.
+	// Defaults to StaticAssetsDir ("static") if empty.
+	AssetsDir string
+
 	// DefaultHandler is used as a fallback handler when no directory or FS is provided.
 	// Typically an http.FileServer or similar.
 	DefaultHandler http.Handler
 
 	// FS specifies an embedded filesystem (like embed.FS) to serve files from.
-	// Requires IndexFile to be set for SPA fallback behavior.
 	FS fs.FS
 
 	// IndexFile is the name of the fallback file to serve for SPA routes (e.g. "index.html").
-	// Required when FS is set.
+	// Only used when MPA is false.
 	IndexFile string
+
+	// MPA enables Multi-Page Application mode where files are served directly instead of SPA fallback.
+	// When true, IndexFile is ignored.
+	MPA bool
 }
 
 // SetupStaticRoutes configures static file serving routes with optional SPA fallback.
@@ -224,40 +288,61 @@ func SetupStaticRoutes(r Router, cfg StaticConfig) error {
 	var handler http.Handler
 	var fsys fs.FS
 
+	// Resolve assets directory name and URL mount prefix
+	assetsDir := cfg.AssetsDir
+	if assetsDir == "" {
+		assetsDir = StaticAssetsDir
+	}
+	assetsPrefix := assetsDir
+	if !strings.HasPrefix(assetsPrefix, "/") {
+		assetsPrefix = "/" + assetsPrefix
+	}
+
+	// Setup filesystem based on configuration
 	if cfg.FS != nil {
 		fsys = cfg.FS
-		// Try to get subdirectory for assets if it exists
-		var staticFS = fsys
-		if _, err := fs.Stat(fsys, StaticAssetsDir); err == nil {
-			subFs, err := fs.Sub(fsys, StaticAssetsDir)
-			if err == nil {
-				staticFS = subFs
-			}
-		}
-		echoRouter.StaticFS(StaticAssetsPath, fsAdapter(staticFS))
+		staticFS := getAssetsSubFS(fsys, assetsDir)
+		echoRouter.StaticFS(assetsPrefix, fsAdapter(staticFS))
 	} else {
+		// Handle directory-based serving
 		dirPath := cfg.DirPath
 		if dirPath == "" && cfg.EnvVar != "" {
 			dirPath = os.Getenv(cfg.EnvVar)
 		}
 
 		if dirPath != "" {
-			assetsPath := filepath.Join(dirPath, StaticAssetsDir) // Keep filepath for disk paths
 			fsys = os.DirFS(dirPath)
-			handler = http.FileServer(http.Dir(dirPath))
-			echoRouter.Static(StaticAssetsPath, assetsPath)
+			staticFS := getAssetsSubFS(fsys, assetsDir)
+			echoRouter.StaticFS(assetsPrefix, fsAdapter(staticFS))
 		} else if cfg.DefaultHandler != nil {
 			handler = cfg.DefaultHandler
 		}
 	}
 
-	if fsys != nil {
+	// Setup favicon routes first
+	setupFaviconRoutes(echoRouter, fsys, handler, cfg)
+
+	// Register routes based on configuration
+	switch {
+	case fsys != nil && cfg.MPA:
+		// MPA mode - serve files directly
+		echoRouter.StaticFS("/", fsAdapter(fsys))
+	case fsys != nil:
+		// SPA mode - fallback to index file
 		return setupSPAFallback(echoRouter, fsys, cfg.IndexFile)
+	case cfg.DefaultHandler != nil:
+		// Use default handler fallback
+		echoRouter.GET("/*", func(c echo.Context) error {
+			if strings.HasPrefix(c.Request().URL.Path, "/api/") {
+				return echo.ErrNotFound
+			}
+			handler.ServeHTTP(c.Response(), c.Request())
+			return nil
+		})
+	default:
+		return errors.New("must provide either DirPath, DefaultHandler, FS or EnvVar")
 	}
-	if handler != nil {
-		return setupDirectoryFallback(echoRouter, handler)
-	}
-	return errors.New("must provide either DirPath, DefaultHandler, FS or EnvVar")
+	return nil
 }
 
 // setupSPAFallback configures route handlers to serve the index file for all unmatched paths,
@@ -270,71 +355,74 @@ func setupSPAFallback(echoRouter *echo.Echo, fsys fs.FS, indexFile string) error
 	if indexFile == "" {
 		indexFile = DefaultIndexFile
 	}
-	
-	// Add favicon route handlers
-	for _, ext := range faviconExts {
-		ext := ext // capture range variable
-		handler := func(c echo.Context, head bool) error {
-			faviconPath := "favicon." + ext
+
+	echoRouter.GET("/*", func(c echo.Context) error {
+		if strings.HasPrefix(c.Request().URL.Path, "/api/") {
+			return echo.ErrNotFound
+		}
+		return fsFile(c, indexFile, fsys)
+	})
+	return nil
+}
+
+func createFaviconHandler(fsys fs.FS, handler http.Handler, cfg StaticConfig, ext string) echo.HandlerFunc {
+	if fsys != nil {
+		return func(c echo.Context) error {
+			faviconPath := strings.TrimPrefix(c.Path(), "/")
 			file, err := fsys.Open(faviconPath)
 			if err != nil {
-				// Try to serve from static directory
-				file, err = fsys.Open(path.Join(StaticAssetsDir, faviconPath))
+				// Try static directory
+				assetsDir := cfg.AssetsDir
+				if assetsDir == "" {
+					assetsDir = StaticAssetsDir
+				}
+				file, err = fsys.Open(path.Join(assetsDir, faviconPath))
 				if err != nil {
 					return echo.ErrNotFound
 				}
 			}
 			defer file.Close()
 
-			// Determine content type from extension
 			var contentType string
 			switch ext {
 			case "png":
 				contentType = "image/png"
 			case "svg":
-				contentType = "image/svg+xml" 
+				contentType = "image/svg+xml"
 			case "gif":
 				contentType = "image/gif"
 			default:
 				contentType = "image/x-icon"
 			}
 
-			// Set common headers
 			h := c.Response().Header()
 			h.Set("Content-Type", contentType)
 			h.Set("Cache-Control", "public, max-age=31536000, immutable")
 
-			if head {
-				// For HEAD requests, just return headers without reading file
-				info, err := file.Stat()
-				if err != nil {
-					return err
-				}
-				h.Set("Content-Length", fmt.Sprintf("%d", info.Size()))
+			if c.Request().Method == http.MethodHead {
 				return c.NoContent(http.StatusOK)
 			}
-			
-			// For GET requests, stream the file content
 			return c.Stream(http.StatusOK, contentType, file)
 		}
-		echoRouter.GET("/favicon."+ext, func(c echo.Context) error { return handler(c, false) })
-		echoRouter.HEAD("/favicon."+ext, func(c echo.Context) error { return handler(c, true) })
+	} else if handler != nil {
+		return func(c echo.Context) error {
+			c.Request().URL.Path = "/favicon." + ext
+			handler.ServeHTTP(c.Response(), c.Request())
+			return nil
+		}
 	}
-	
-	echoRouter.GET("/*", func(c echo.Context) error {
-		if strings.HasPrefix(c.Request().URL.Path, "/api/") {
-			return echo.ErrNotFound
-		}
-
-		file, err := fsys.Open(indexFile)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-
-		return c.Stream(http.StatusOK, "text/html", file)
-	})
 	return nil
+}
+
+func setupFaviconRoutes(echoRouter *echo.Echo, fsys fs.FS, handler http.Handler, cfg StaticConfig) {
+	for _, ext := range faviconExts {
+		ext := ext // capture range variable
+		serve := createFaviconHandler(fsys, handler, cfg, ext)
+		if serve != nil {
+			echoRouter.GET("/favicon."+ext, serve)
+			echoRouter.HEAD("/favicon."+ext, serve)
+		}
+	}
 }
 
 // setupDirectoryFallback configures route handlers to serve files from a directory
@@ -366,7 +454,7 @@ func setupDirectoryFallback(echoRouter *echo.Echo, handler http.Handler) error {
 		echoRouter.GET("/favicon."+ext, serve)
 		echoRouter.HEAD("/favicon."+ext, serve)
 	}
-	
+
 	echoRouter.GET("/*", func(c echo.Context) error {
 		if !strings.HasPrefix(c.Request().URL.Path, "/api/") {
 			c.Request().URL.Path = "/"
@@ -384,4 +472,31 @@ func MustSetupStaticRoutes(r Router, cfg StaticConfig) {
 	if err := SetupStaticRoutes(r, cfg); err != nil {
 		panic(fmt.Sprintf("Failed to setup static routes: %v", err))
 	}
+}
+
+func fsFile(c echo.Context, file string, filesystem fs.FS) error {
+	f, err := filesystem.Open(file)
+	if err != nil {
+		return echo.ErrNotFound
+	}
+	defer f.Close()
+
+	fi, _ := f.Stat()
+	if fi.IsDir() {
+		file = filepath.ToSlash(filepath.Join(file, DefaultIndexFile)) // ToSlash is necessary for Windows. fs.Open and os.Open are different in that aspect.
+		f, err = filesystem.Open(file)
+		if err != nil {
+			return echo.ErrNotFound
+		}
+		defer f.Close()
+		if fi, err = f.Stat(); err != nil {
+			return err
+		}
+	}
+	ff, ok := f.(io.ReadSeeker)
+	if !ok {
+		return errors.New("file does not implement io.ReadSeeker")
+	}
+	http.ServeContent(c.Response(), c.Request(), fi.Name(), fi.ModTime(), ff)
+	return nil
 }

--- a/static_helpers_test.go
+++ b/static_helpers_test.go
@@ -491,6 +491,176 @@ func TestSetupStaticRoutes(t *testing.T) {
 	})
 }
 
+func TestMPASetupWithAssets(t *testing.T) {
+	mockFS := fstest.MapFS{
+		"custom_assets/style.css": &fstest.MapFile{
+			Data: []byte("body { color: red; }"),
+		},
+		"index.html": &fstest.MapFile{
+			Data: []byte("<html>index</html>"),
+		},
+	}
+
+	r, err := NewRouter(APIInfo().Title("Test").Version("1.0"))
+	require.NoError(t, err)
+
+	err = MPASetupWithAssets(r, mockFS, "custom_assets")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/custom_assets/style.css", nil)
+	rr := httptest.NewRecorder()
+	GetRouter(r).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "body { color: red; }", rr.Body.String())
+}
+
+func TestMustMPASetupWithAssets(t *testing.T) {
+	r, err := NewRouter(APIInfo().Title("Test").Version("1.0"))
+	require.NoError(t, err)
+
+	mockFS := fstest.MapFS{
+		"custom_assets/style.css": &fstest.MapFile{
+			Data: []byte("body { color: red; }"),
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		MustMPASetupWithAssets(r, mockFS, "custom_assets")
+	})
+}
+
+func TestMPASupport(t *testing.T) {
+	t.Run("serves multiple html pages from embedded FS", func(t *testing.T) {
+		mockFS := fstest.MapFS{
+			"index.html": &fstest.MapFile{
+				Data: []byte("<html>index</html>"),
+			},
+			"about.html": &fstest.MapFile{
+				Data: []byte("<html>about</html>"), 
+			},
+			"contact.html": &fstest.MapFile{
+				Data: []byte("<html>contact</html>"),
+			},
+			StaticAssetsDir + "/style.css": &fstest.MapFile{
+				Data: []byte("body { color: red; }"),
+			},
+		}
+
+		r, err := NewRouter(APIInfo().Title("Test").Version("1.0"))
+		require.NoError(t, err)
+
+		err = SetupStaticRoutes(r, StaticConfig{
+			FS:  mockFS,
+			MPA: true, // Enable MPA mode
+		})
+		require.NoError(t, err)
+
+		cases := []struct {
+			path string
+			want string
+		}{
+			{"/", "<html>index</html>"},
+			{"/about.html", "<html>about</html>"},
+			{"/contact.html", "<html>contact</html>"},
+			{StaticAssetsPath + "/style.css", "body { color: red; }"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.path, func(t *testing.T) {
+				req := httptest.NewRequest("GET", tc.path, nil)
+				rr := httptest.NewRecorder()
+				GetRouter(r).ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusOK, rr.Code)
+				assert.Equal(t, tc.want, rr.Body.String())
+			})
+		}
+
+		// Test API routes still return 404
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		rr := httptest.NewRecorder()
+		GetRouter(r).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("serves multiple html pages from directory", func(t *testing.T) {
+		dir := t.TempDir()
+		files := map[string]string{
+			"index.html":   "<html>index</html>",
+			"about.html":   "<html>about</html>",
+			"contact.html": "<html>contact</html>",
+			StaticAssetsDir + "/style.css": "body { color: red; }",
+		}
+
+		for name, content := range files {
+			path := filepath.Join(dir, name)
+			err := os.MkdirAll(filepath.Dir(path), 0755)
+			require.NoError(t, err)
+			err = os.WriteFile(path, []byte(content), 0644)
+			require.NoError(t, err)
+		}
+
+		r, err := NewRouter(APIInfo().Title("Test").Version("1.0"))
+		require.NoError(t, err)
+
+		err = SetupStaticRoutes(r, StaticConfig{
+			DirPath: dir,
+			MPA:     true, // Enable MPA mode
+		})
+		require.NoError(t, err)
+
+		cases := []struct {
+			path string
+			want string
+		}{
+			{"/", "<html>index</html>"},
+			{"/about.html", "<html>about</html>"},
+			{"/contact.html", "<html>contact</html>"},
+			{StaticAssetsPath + "/style.css", "body { color: red; }"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.path, func(t *testing.T) {
+				req := httptest.NewRequest("GET", tc.path, nil)
+				rr := httptest.NewRecorder()
+				GetRouter(r).ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusOK, rr.Code)
+				assert.Equal(t, tc.want, rr.Body.String())
+			})
+		}
+	})
+
+	t.Run("ignores indexFile in MPA mode", func(t *testing.T) {
+		mockFS := fstest.MapFS{
+			"index.html": &fstest.MapFile{
+				Data: []byte("<html>index</html>"),
+			},
+			"other.html": &fstest.MapFile{
+				Data: []byte("<html>other</html>"),
+			},
+		}
+
+		r, err := NewRouter(APIInfo().Title("Test").Version("1.0"))
+		require.NoError(t, err)
+
+		err = SetupStaticRoutes(r, StaticConfig{
+			FS:        mockFS,
+			IndexFile: "other.html", // Should be ignored
+			MPA:       true,
+		})
+		require.NoError(t, err)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rr := httptest.NewRecorder()
+		GetRouter(r).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "<html>index</html>", rr.Body.String())
+	})
+}
+
 func TestSPAFallback(t *testing.T) {
 	t.Run("serves index.html for unknown paths", func(t *testing.T) {
 		r, err := NewRouter(APIInfo().Title("Test").Version("1.0"))


### PR DESCRIPTION
- Added Multi-Page Application (MPA) mode support via new MPA flag in StaticConfig
- Refactored static file serving logic to handle both SPA and MPA modes
- Improved assets directory handling with getAssetsSubFS helper
- Added new helper functions (MPASetup, MPASetupWithAssets) with panic variants
- Enhanced favicon handling with dedicated setupFaviconRoutes function
- Added tests for MPA functionality
- Made AssetsDir configurable while keeping backward compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-Page Application (MPA) support for static sites with configurable assets directory and mounting from embedded or disk sources.
  * Improved static-file serving including SPA fallback behavior, directory indexing, and enhanced favicon responses (correct headers and HEAD handling).
  * Smarter routing that selects MPA, SPA, or default handlers.

* **Tests**
  * Added tests covering MPA mode, asset delivery, routing, and favicon behavior across embedded and directory setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->