### PR TITLE
feat(router): configure IP extraction from X-Forwarded-For header

### DIFF
--- a/router.go
+++ b/router.go
@@ -2,11 +2,12 @@ package router
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/invopop/jsonschema"
 	"go.lumeweb.com/gswagger/apirouter"
 	"go.lumeweb.com/portal-middleware/cors"
-	"net/http"
-	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
@@ -74,9 +75,15 @@ func GetGroupRouter(r Router) *echo.Group {
 //	    log.Fatal(err)
 //	}
 func NewSwaggerRouter(info APIInfoDefinition, opts ...RouterOption) (Router, error) {
+	echoFactory := func() *echo.Echo {
+		e := echo.New()
+		e.IPExtractor = echo.ExtractIPFromXFFHeader()
+		return e
+	}
+
 	// Initialize config with defaults
 	config := &RouterConfig{
-		EchoRouter: echo.New(),
+		EchoRouter: echoFactory(),
 		OpenAPI: &openapi3.T{
 			Info: info.toOpenAPI(),
 			Servers: []*openapi3.Server{
@@ -89,7 +96,7 @@ func NewSwaggerRouter(info APIInfoDefinition, opts ...RouterOption) (Router, err
 			JSONDocumentationPath: SwaggerJSONPath,
 			YAMLDocumentationPath: SwaggerYAMLPath,
 			FrameworkRouterFactory: func() apirouter.Router[echo.HandlerFunc, echo.MiddlewareFunc, es.Route] {
-				return es.NewRouter(echo.New())
+				return es.NewRouter(echoFactory())
 			},
 		},
 	}

--- a/router.go
+++ b/router.go
@@ -77,6 +77,8 @@ func GetGroupRouter(r Router) *echo.Group {
 func NewSwaggerRouter(info APIInfoDefinition, opts ...RouterOption) (Router, error) {
 	echoFactory := func() *echo.Echo {
 		e := echo.New()
+		// Trusted proxy assumption: service should be behind reverse proxy like nginx/Cloudflare
+		// Do not expose service directly to untrusted networks
 		e.IPExtractor = echo.ExtractIPFromXFFHeader()
 		return e
 	}


### PR DESCRIPTION
- Set Echo's IPExtractor to use X-Forwarded-For header for client IP detection
- Improves accuracy of client IP identification in proxied environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects client IP detection behind proxies by consistently honoring X-Forwarded-For across all routes, improving logging, analytics, and IP-based features.
  * Ensures OpenAPI/Swagger endpoints use the same IP extraction behavior as the main app, avoiding mismatched IP reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->