### PR TITLE
fix(swagger): update file upload schema to use binary format

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -64,7 +64,7 @@ func WithFileUpload(description string, required bool) SwaggerOption {
 			Content: map[string]swagger.Schema{
 				"multipart/form-data": {
 					Value: struct {
-						File string `json:"file" form:"file"`
+						File string `json:"file" jsonschema:"type=string,format=binary"`
 					}{},
 				},
 			},


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updates the Swagger schema definition for file upload parameters. The `File` field within `multipart/form-data` requests is now explicitly marked with `type=string,format=binary` in its JSON schema. This change ensures that file uploads are correctly represented in the generated OpenAPI documentation and Swagger UI.
<!-- kody-pr-summary:end -->