### PR TITLE
feat: add WithoutDefaultSuccessResponse option for custom success codes

### DIFF
--- a/route_builder.go
+++ b/route_builder.go
@@ -71,6 +71,9 @@ func applyRouteOpts(d RouteDefinition, opts ...RouteOption) RouteDefinition {
 		}
 	}
 
+	// Apply default Swagger responses for consistency
+	applySwaggerDefaults(&result.Swagger)
+
 	// Prepend CORS middleware if configured
 	if result.CorsConfig != nil {
 		corsHandler := cors.NewWithDefaults(*result.CorsConfig)

--- a/route_builder.go
+++ b/route_builder.go
@@ -77,14 +77,6 @@ func applyRouteOpts(d RouteDefinition, opts ...RouteOption) RouteDefinition {
 		result.Middlewares = append([]echo.MiddlewareFunc{echo.WrapMiddleware(corsHandler)}, result.Middlewares...)
 	}
 
-	// Ensure we have at least the default success response, preserving existing ones
-	result.Swagger.Responses = MergeResponses(
-		result.Swagger.Responses,
-		map[int]swagger.ContentValue{
-			http.StatusOK: defaultSuccessResponse(),
-		},
-	)
-
 	return result
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -236,6 +236,14 @@ func TestSwaggerDocsServed(t *testing.T) {
 			Path:    "/test",
 			Method:  "GET",
 			Handler: func(c echo.Context) error { return nil },
+			Swagger: swagger.Definitions{
+				Responses: map[int]swagger.ContentValue{
+					http.StatusOK: {
+						Description: "Success",
+						Content:     swagger.Content{MediaTypeJSON: {Value: map[string]string{"message": "OK"}}},
+					},
+				},
+			},
 		},
 	)
 	err = RegisterRoutes(eRouter, nil, "", routes)

--- a/swagger.go
+++ b/swagger.go
@@ -148,11 +148,8 @@ func WithSwagger(opts ...SwaggerOption) RouteOption {
 			d.Swagger.Responses = make(map[int]swagger.ContentValue)
 		}
 
-		// Add default success response for backward compatibility
-		// Only add if not already present (users can override by using WithoutDefaultSuccessResponse())
-		if _, ok := d.Swagger.Responses[http.StatusOK]; !ok {
-			d.Swagger.Responses[http.StatusOK] = defaultSuccessResponse()
-		}
+		// Apply default Swagger responses
+		applySwaggerDefaults(&d.Swagger)
 
 		// Merge default error responses into existing responses, preserving existing success responses
 		d.Swagger.Responses = MergeResponses(d.Swagger.Responses, defaultErrors)
@@ -352,11 +349,15 @@ func DefineResponse(status int, description string, opts ...ResponseOption) map[
 // WithoutDefaultSuccessResponse removes the default 200 OK response from swagger definitions.
 // Use this when an endpoint returns a different success status code (e.g., 302 redirect, 201 created).
 // This option should be used alongside WithSuccessResponse to define the custom success response.
+// Sets a marker to prevent applySwaggerDefaults from re-adding the 200 response.
 func WithoutDefaultSuccessResponse() SwaggerOption {
 	return func(d *swagger.Definitions, accessRole string) {
-		if d.Responses != nil {
-			delete(d.Responses, http.StatusOK)
+		if d.Responses == nil {
+			d.Responses = make(map[int]swagger.ContentValue)
 		}
+		delete(d.Responses, http.StatusOK)
+		// Set marker to prevent re-adding 200 in applySwaggerDefaults
+		d.Responses[-1] = swagger.ContentValue{Description: "NO_DEFAULT_200"}
 	}
 }
 

--- a/swagger.go
+++ b/swagger.go
@@ -130,6 +130,7 @@ func WithDescription(description string) SwaggerOption {
 
 // WithSwagger creates a RouteOption that sets the Swagger documentation definitions
 // for a route. Automatically includes appropriate error responses based on access level.
+// Adds a default 200 OK success response for backward compatibility.
 // Preserves any existing success responses (2xx status codes) and allows custom
 // success responses from options to be merged.
 func WithSwagger(opts ...SwaggerOption) RouteOption {
@@ -145,6 +146,12 @@ func WithSwagger(opts ...SwaggerOption) RouteOption {
 		// Initialize responses if nil
 		if d.Swagger.Responses == nil {
 			d.Swagger.Responses = make(map[int]swagger.ContentValue)
+		}
+
+		// Add default success response for backward compatibility
+		// Only add if not already present (users can override by using WithoutDefaultSuccessResponse())
+		if _, ok := d.Swagger.Responses[http.StatusOK]; !ok {
+			d.Swagger.Responses[http.StatusOK] = defaultSuccessResponse()
 		}
 
 		// Merge default error responses into existing responses, preserving existing success responses
@@ -339,6 +346,17 @@ func DefineResponse(status int, description string, opts ...ResponseOption) map[
 
 	return map[int]swagger.ContentValue{
 		status: contentValue,
+	}
+}
+
+// WithoutDefaultSuccessResponse removes the default 200 OK response from swagger definitions.
+// Use this when an endpoint returns a different success status code (e.g., 302 redirect, 201 created).
+// This option should be used alongside WithSuccessResponse to define the custom success response.
+func WithoutDefaultSuccessResponse() SwaggerOption {
+	return func(d *swagger.Definitions, accessRole string) {
+		if d.Responses != nil {
+			delete(d.Responses, http.StatusOK)
+		}
 	}
 }
 

--- a/util.go
+++ b/util.go
@@ -31,6 +31,23 @@ func baseDefinition() swagger.Definitions {
 	return def
 }
 
+// applySwaggerDefaults applies default Swagger responses to ensure consistent
+// documentation across all routes. Adds 200 OK if not already present.
+func applySwaggerDefaults(def *swagger.Definitions) {
+	if def.Responses == nil {
+		def.Responses = make(map[int]swagger.ContentValue)
+	}
+	// Check if user explicitly opted out of default 200 response
+	// WithoutDefaultSuccessResponse sets a marker (-1) to prevent re-adding
+	if _, hasNoDefaultMarker := def.Responses[-1]; hasNoDefaultMarker {
+		delete(def.Responses, -1) // Clean up marker
+		return // Skip adding 200
+	}
+	if _, ok := def.Responses[http.StatusOK]; !ok {
+		def.Responses[http.StatusOK] = defaultSuccessResponse()
+	}
+}
+
 // defaultSuccessResponse returns the standard success response structure
 func defaultSuccessResponse() swagger.ContentValue {
 	return swagger.ContentValue{


### PR DESCRIPTION
Add WithoutDefaultSuccessResponse() SwaggerOption to allow endpoints to
opt-out of default 200 OK response when returning different success codes
(e.g., 302 redirect, 201 created). Maintains backward compatibility by
adding 200 response by default in NewRoute() and WithSwagger().

Changes:
- Add WithoutDefaultSuccessResponse() option in swagger.go
- Modify WithSwagger() to only add 200 if not already present
- Modify NewRoute() to include 200 by default
- Update tests to reflect new behavior


---

<!-- kody-pr-summary:start -->
 This PR introduces the `WithoutDefaultSuccessResponse()` option, enabling endpoints to opt-out of the automatic 200 OK success response in Swagger documentation. This allows proper documentation of endpoints that return alternative success status codes (e.g., 201 Created, 302 Redirect) without the default 200 OK appearing in the generated specs.

**Key Changes:**
- **New Option**: Added `WithoutDefaultSuccessResponse()` swagger option that removes the default 200 OK response from the swagger definitions
- **Logic Refactoring**: Moved the default success response injection from `applyRouteOpts()` into the `WithSwagger()` function, allowing the new opt-out option to function correctly
- **Backward Compatibility**: Maintains existing behavior by automatically adding a 200 OK response when `WithSwagger` is used and no custom success response is already defined
- **Test Updates**: Modified tests to explicitly define success responses where the unconditional default was previously relied upon

This resolves the issue where the default 200 OK response was unconditionally applied to all routes at the end of option processing, making it impossible to document endpoints with non-200 success status codes accurately.
<!-- kody-pr-summary:end -->