### PR TITLE
fix: preserve opt-out marker through multiple applySwaggerDefaults calls

### DIFF
--- a/router.go
+++ b/router.go
@@ -330,6 +330,9 @@ func RegisterRoutes(
 		// Apply all route options including common ones
 		finalRoute := applyRouteOpts(route, commonOpts...)
 
+		// Clean up internal markers before registering
+		clearSwaggerMarkers(&finalRoute.Swagger)
+
 		// Register route with router
 		_, err := group.AddRoute(
 			finalRoute.Method,

--- a/util.go
+++ b/util.go
@@ -37,14 +37,19 @@ func applySwaggerDefaults(def *swagger.Definitions) {
 	if def.Responses == nil {
 		def.Responses = make(map[int]swagger.ContentValue)
 	}
-	// Check if user explicitly opted out of default 200 response
-	// WithoutDefaultSuccessResponse sets a marker (-1) to prevent re-adding
 	if _, hasNoDefaultMarker := def.Responses[-1]; hasNoDefaultMarker {
-		delete(def.Responses, -1) // Clean up marker
-		return // Skip adding 200
+		return
 	}
 	if _, ok := def.Responses[http.StatusOK]; !ok {
 		def.Responses[http.StatusOK] = defaultSuccessResponse()
+	}
+}
+
+// clearSwaggerMarkers removes internal markers from swagger definitions.
+// Called in RegisterRoutes before passing swagger to the router.
+func clearSwaggerMarkers(def *swagger.Definitions) {
+	if def.Responses != nil {
+		delete(def.Responses, -1)
 	}
 }
 


### PR DESCRIPTION
The WithoutDefaultSuccessResponse option uses a marker (-1) to prevent the
default 200 OK response from being added. Previously, applySwaggerDefaults removed
this marker on first call, causing it to be re-added on subsequent calls (e.g., in
applyRouteOpts).

Fix:
- Don't remove marker in applySwaggerDefaults
- Add clearSwaggerMarkers helper to clean up markers before registration
- Call clearSwaggerMarkers in RegisterRoutes before passing swagger to router


---

<!-- kody-pr-summary:start -->
 Fixes a bug where routes configured to opt out of default success responses would incorrectly receive them when swagger defaults were processed multiple times.

**Changes:**
- Modified `applySwaggerDefaults` to preserve the internal opt-out marker (-1) through multiple processing passes instead of immediately deleting it
- Added `clearSwaggerMarkers` function to clean up internal markers only at final registration time
- Updated `RegisterRoutes` to call marker cleanup immediately before passing swagger definitions to the router

**Impact:**
Routes using `WithoutDefaultSuccessResponse()` will now correctly maintain their opt-out status throughout the entire route registration pipeline, ensuring no default 200 response is added when explicitly excluded.
<!-- kody-pr-summary:end -->