### PR TITLE
fix(core): Change OpenAPI server URL from /api to / to fix documentation issues

### DIFF
--- a/router.go
+++ b/router.go
@@ -92,7 +92,7 @@ func NewSwaggerRouter(info APIInfoDefinition, opts ...RouterOption) (Router, err
 			Info: info.toOpenAPI(),
 			Servers: []*openapi3.Server{
 				{
-					URL: "/api",
+					URL: "/",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Change the OpenAPI server URL from `/api` to `/` to fix documentation issues where the generated OpenAPI/Swagger specification incorrectly prefixed all API endpoint paths with `/api`, causing a mismatch between the documented and actual endpoint URLs.
<!-- kody-pr-summary:end -->