### PR TITLE
feat: add VITE_PORTAL_BRAND support to AppFilesystem

### DIFF
--- a/app_fs.go
+++ b/app_fs.go
@@ -18,7 +18,7 @@ var _ fs.FS = (*AppFilesystem)(nil)
 var _ fs.FileInfo = (*appFileInfo)(nil)
 
 // loaderLogoRe matches <div data-loader-logo ...>inner content</div>
-var loaderLogoRe = regexp.MustCompile(`(<div\s+data-loader-logo\s+[^>]*>)([\s\S]*?)(</div>)`)
+var loaderLogoRe = regexp.MustCompile(`(<div\s+data-loader-logo(?:\s+[^>]*)?>)([\s\S]*?)(</div>)`)
 
 type AppFilesystemConfig struct {
 	Domain    string

--- a/app_fs.go
+++ b/app_fs.go
@@ -2,51 +2,64 @@ package router
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
+	"regexp"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"golang.org/x/net/html"
 )
 
-const scriptTemplate = `window.VITE_PORTAL_DOMAIN = '{{.Domain}}';
-window.VITE_PORTAL_DOMAIN_IS_ROOT = {{.IsSubdomain}};`
-
 var _ fs.FS = (*AppFilesystem)(nil)
 var _ fs.FileInfo = (*appFileInfo)(nil)
+
+// loaderLogoRe matches <div data-loader-logo ...>inner content</div>
+var loaderLogoRe = regexp.MustCompile(`(<div\s+data-loader-logo\s+[^>]*>)([\s\S]*?)(</div>)`)
+
+type AppFilesystemConfig struct {
+	Domain    string
+	BrandJSON string
+}
+
+type BrandConfig struct {
+	LogoURL string `json:"logoUrl"`
+}
 
 // AppFilesystem wraps an fs.FS to modify index.html content before serving it.
 // It caches the modified content after first read for better performance.
 type AppFilesystem struct {
-	fs                fs.FS
-	cache             *bytes.Buffer
-	cached            bool
-	mu                sync.Mutex
-	portalDomain      string
-	portalIsSubdomain bool
-	scriptTmpl        *template.Template
+	fs           fs.FS
+	cache        *bytes.Buffer
+	cached       bool
+	mu           sync.Mutex
+	config       AppFilesystemConfig
+	isSubdomain  bool
+	brandLogoURL string
 }
 
 // NewAppFilesystem creates a new AppFilesystem wrapping the provided fs.FS.
-// It automatically determines if the portalDomain is a subdomain using IsSubdomain.
-func NewAppFilesystem(fsys fs.FS, portalDomain string) *AppFilesystem {
-	tmpl, err := template.New("portalVars").Parse(scriptTemplate)
-	if err != nil {
-		panic(fmt.Sprintf("failed to parse portal vars template: %v", err))
+// It automatically determines if the config.Domain is a subdomain using IsSubdomain.
+func NewAppFilesystem(fsys fs.FS, config AppFilesystemConfig) *AppFilesystem {
+	a := &AppFilesystem{
+		fs:          fsys,
+		cache:       new(bytes.Buffer),
+		cached:      false,
+		config:      config,
+		isSubdomain: IsSubdomain(config.Domain),
 	}
 
-	return &AppFilesystem{
-		fs:                fsys,
-		cache:             new(bytes.Buffer),
-		cached:            false,
-		portalDomain:      portalDomain,
-		portalIsSubdomain: IsSubdomain(portalDomain),
-		scriptTmpl:        tmpl,
+	if config.BrandJSON != "" {
+		var brand BrandConfig
+		if err := json.Unmarshal([]byte(config.BrandJSON), &brand); err == nil {
+			a.brandLogoURL = brand.LogoURL
+		}
 	}
+
+	return a
 }
 
 // Open implements fs.FS interface.
@@ -75,10 +88,8 @@ func (a *AppFilesystem) Open(name string) (fs.File, error) {
 		return nil, err
 	}
 
-	// Modify the content as needed
 	modified := a.modifyIndexHTML(content)
 
-	// Cache the modified content
 	a.cache.Reset()
 	a.cache.Write(modified)
 	a.cached = true
@@ -89,62 +100,59 @@ func (a *AppFilesystem) Open(name string) (fs.File, error) {
 	}, nil
 }
 
-// modifyIndexHTML processes the index.html content to inject portal variables
 func (a *AppFilesystem) modifyIndexHTML(content []byte) []byte {
+	// Logo replacement on raw HTML before DOM parsing — regex is more reliable
+	// than DOM round-tripping for this specific nested-content pattern.
+	if a.brandLogoURL != "" {
+		replacement := fmt.Sprintf(`$1<img alt="Logo" src="%s" />$3`, html.EscapeString(a.brandLogoURL))
+		content = loaderLogoRe.ReplaceAll(content, []byte(replacement))
+	}
+
 	doc, err := html.Parse(bytes.NewReader(content))
 	if err != nil {
 		return content // fallback to original if parsing fails
 	}
 
 	var head *html.Node
-	var f func(*html.Node)
-	f = func(n *html.Node) {
+	var findHead func(*html.Node)
+	findHead = func(n *html.Node) {
 		if n.Type == html.ElementNode && n.Data == "head" {
 			head = n
 			return
 		}
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			f(c)
+			findHead(c)
 		}
 	}
-	f(doc)
+	findHead(doc)
 
 	if head == nil {
 		return content // no head tag found
 	}
 
-	// Create script node with portal variables
-	script := &html.Node{
-		Type: html.ElementNode,
-		Data: "script",
-		Attr: []html.Attribute{
-			{Key: "type", Val: "text/javascript"},
-		},
-	}
+	// Build script tags in reverse order — we prepend each to <head>,
+	// so prepending in reverse produces correct final DOM order.
+	scripts := a.buildScriptContent()
 
-	var scriptBuf bytes.Buffer
-	err = a.scriptTmpl.Execute(&scriptBuf, struct {
-		Domain      string
-		IsSubdomain bool
-	}{
-		Domain:      html.EscapeString(a.portalDomain),
-		IsSubdomain: a.portalIsSubdomain,
-	})
-	if err != nil {
-		return content
-	}
+	for i := len(scripts) - 1; i >= 0; i-- {
+		scriptNode := &html.Node{
+			Type: html.ElementNode,
+			Data: "script",
+			Attr: []html.Attribute{
+				{Key: "type", Val: "text/javascript"},
+			},
+		}
+		textNode := &html.Node{
+			Type: html.TextNode,
+			Data: scripts[i],
+		}
+		scriptNode.AppendChild(textNode)
 
-	scriptText := &html.Node{
-		Type: html.TextNode,
-		Data: scriptBuf.String(),
-	}
-	script.AppendChild(scriptText)
-	
-	// Insert as first child of head
-	if head.FirstChild != nil {
-		head.InsertBefore(script, head.FirstChild)
-	} else {
-		head.AppendChild(script)
+		if head.FirstChild != nil {
+			head.InsertBefore(scriptNode, head.FirstChild)
+		} else {
+			head.AppendChild(scriptNode)
+		}
 	}
 
 	var buf bytes.Buffer
@@ -153,6 +161,27 @@ func (a *AppFilesystem) modifyIndexHTML(content []byte) []byte {
 	}
 
 	return buf.Bytes()
+}
+
+func (a *AppFilesystem) buildScriptContent() []string {
+	var scripts []string
+
+	if a.config.Domain != "" {
+		scripts = append(scripts, fmt.Sprintf("window.VITE_PORTAL_DOMAIN = '%s';", html.EscapeString(a.config.Domain)))
+		scripts = append(scripts, fmt.Sprintf("window.VITE_PORTAL_DOMAIN_IS_ROOT = %t;", a.isSubdomain))
+	}
+
+	if a.config.BrandJSON != "" {
+		// json.Marshal on a string is equivalent to JS JSON.stringify() —
+		// produces a quoted, escaped string literal safe for JS assignment.
+		brandJS, err := json.Marshal(a.config.BrandJSON)
+		if err != nil {
+			brandJS = []byte(`""`)
+		}
+		scripts = append(scripts, fmt.Sprintf("window.VITE_PORTAL_BRAND = %s;", string(brandJS)))
+	}
+
+	return scripts
 }
 
 // appCachedFile implements fs.File for cached content
@@ -183,4 +212,4 @@ func (fi *appFileInfo) Size() int64        { return fi.size }
 func (fi *appFileInfo) Mode() fs.FileMode  { return 0444 } // Read-only
 func (fi *appFileInfo) ModTime() time.Time { return time.Now() }
 func (fi *appFileInfo) IsDir() bool        { return false }
-func (fi *appFileInfo) Sys() interface{}   { return nil }
+func (fi *appFileInfo) Sys() any          { return nil }

--- a/app_fs_test.go
+++ b/app_fs_test.go
@@ -20,25 +20,24 @@ func TestNewAppFilesystem(t *testing.T) {
 	})
 
 	portalDomain := "example.com"
-	appFS := NewAppFilesystem(fsys, portalDomain)
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{Domain: portalDomain})
 
 	if appFS == nil {
 		t.Fatal("NewAppFilesystem returned nil")
 	}
 
-	if appFS.portalDomain != portalDomain {
-		t.Errorf("portalDomain is not set correctly. Expected: %s, got: %s", portalDomain, appFS.portalDomain)
+	if appFS.config.Domain != portalDomain {
+		t.Errorf("Domain not set correctly. Expected: %s, got: %s", portalDomain, appFS.config.Domain)
 	}
 
-	if appFS.portalIsSubdomain {
-		t.Error("portalIsSubdomain should be false for example.com")
+	if appFS.isSubdomain {
+		t.Error("isSubdomain should be false for example.com")
 	}
 
-	portalDomain = "sub.example.co.uk"
-	appFS = NewAppFilesystem(fsys, portalDomain)
+	appFS = NewAppFilesystem(fsys, AppFilesystemConfig{Domain: "sub.example.co.uk"})
 
-	if !appFS.portalIsSubdomain {
-		t.Error("portalIsSubdomain should be true for sub.example.co.uk")
+	if !appFS.isSubdomain {
+		t.Error("isSubdomain should be true for sub.example.co.uk")
 	}
 }
 
@@ -48,8 +47,7 @@ func TestAppFilesystem_Open_NonIndex(t *testing.T) {
 		"static/app.js":  `console.log("app.js");`,
 	})
 
-	portalDomain := "example.com"
-	appFS := NewAppFilesystem(fsys, portalDomain)
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{Domain: "example.com"})
 
 	file, err := appFS.Open("static/app.js")
 	if err != nil {
@@ -79,8 +77,7 @@ func TestAppFilesystem_Open_Index(t *testing.T) {
 		"static/app.js":  `console.log("app.js");`,
 	})
 
-	portalDomain := "example.com"
-	appFS := NewAppFilesystem(fsys, portalDomain)
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{Domain: "example.com"})
 
 	file, err := appFS.Open(DefaultIndexFile)
 	if err != nil {
@@ -99,16 +96,24 @@ func TestAppFilesystem_Open_Index(t *testing.T) {
 	}
 
 	contentStr := string(content)
+
+	// Domain and isRoot should be in separate script tags
 	if !strings.Contains(contentStr, "window.VITE_PORTAL_DOMAIN = 'example.com'") {
 		t.Errorf("Modified index.html does not contain portal domain: %s", contentStr)
 	}
 
-	if strings.Contains(contentStr, "window.VITE_PORTAL_DOMAIN_IS_ROOT = true") {
-		t.Errorf("Modified index.html incorrectly contains portal is root: %s", contentStr)
+	if !strings.Contains(contentStr, "window.VITE_PORTAL_DOMAIN_IS_ROOT = false") {
+		t.Errorf("Modified index.html does not contain VITE_PORTAL_DOMAIN_IS_ROOT = false: %s", contentStr)
 	}
 
-	if !strings.Contains(contentStr, "<script type=\"text/javascript\">window.VITE_PORTAL_DOMAIN") {
-		t.Errorf("Modified index.html does not contain script tag: %s", contentStr)
+	if strings.Contains(contentStr, "VITE_PORTAL_BRAND") {
+		t.Errorf("Modified index.html should not contain VITE_PORTAL_BRAND when not configured: %s", contentStr)
+	}
+
+	// Verify both script tags exist
+	scriptCount := strings.Count(contentStr, `<script type="text/javascript">`)
+	if scriptCount != 2 {
+		t.Errorf("Expected 2 script tags, got %d: %s", scriptCount, contentStr)
 	}
 
 	// Parse HTML to verify script position
@@ -122,9 +127,9 @@ func TestAppFilesystem_Open_Index(t *testing.T) {
 		t.Fatal("No head element found in modified HTML")
 	}
 
-	// Verify script is first child
+	// Verify first child is a script tag
 	if head.FirstChild == nil || head.FirstChild.Data != "script" {
-		t.Error("Script tag is not first child of head")
+		t.Error("First child of head is not a script tag")
 	}
 }
 
@@ -133,8 +138,7 @@ func TestAppFilesystem_Open_Index_EmptyHead(t *testing.T) {
 		DefaultIndexFile: `<html><head></head><body><h1>Hello</h1></body></html>`,
 	})
 
-	portalDomain := "example.com"
-	appFS := NewAppFilesystem(fsys, portalDomain)
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{Domain: "example.com"})
 
 	file, err := appFS.Open(DefaultIndexFile)
 	if err != nil {
@@ -157,7 +161,6 @@ func TestAppFilesystem_Open_Index_EmptyHead(t *testing.T) {
 		t.Errorf("Modified index.html does not contain script tag: %s", contentStr)
 	}
 
-	// Parse HTML to verify script position
 	doc, err := html.Parse(strings.NewReader(contentStr))
 	if err != nil {
 		t.Fatalf("Failed to parse modified HTML: %v", err)
@@ -168,12 +171,8 @@ func TestAppFilesystem_Open_Index_EmptyHead(t *testing.T) {
 		t.Fatal("No head element found in modified HTML")
 	}
 
-	// Verify script is only child
 	if head.FirstChild == nil || head.FirstChild.Data != "script" {
 		t.Error("Script tag is not first child of head")
-	}
-	if head.FirstChild != head.LastChild {
-		t.Error("Head contains more than just the script tag")
 	}
 }
 
@@ -183,10 +182,8 @@ func TestAppFilesystem_Open_Index_Cached(t *testing.T) {
 		"static/app.js":  `console.log("app.js");`,
 	})
 
-	portalDomain := "example.com"
-	appFS := NewAppFilesystem(fsys, portalDomain)
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{Domain: "example.com"})
 
-	// First open to cache the content
 	file1, err := appFS.Open(DefaultIndexFile)
 	if err != nil {
 		t.Fatalf("Failed to open index.html: %v", err)
@@ -203,7 +200,6 @@ func TestAppFilesystem_Open_Index_Cached(t *testing.T) {
 		t.Fatalf("Failed to read index.html: %v", err)
 	}
 
-	// Second open to retrieve from cache
 	file2, err := appFS.Open(DefaultIndexFile)
 	if err != nil {
 		t.Fatalf("Failed to open index.html from cache: %v", err)
@@ -231,8 +227,7 @@ func TestAppFilesystem_ModifyIndexHTML_NoHead(t *testing.T) {
 		DefaultIndexFile: `<html><body><h1>Hello</h1></body></html>`,
 	})
 
-	portalDomain := "example.com"
-	appFS := NewAppFilesystem(fsys, portalDomain)
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{Domain: "example.com"})
 
 	file, err := appFS.Open(DefaultIndexFile)
 	if err != nil {
@@ -256,7 +251,212 @@ func TestAppFilesystem_ModifyIndexHTML_NoHead(t *testing.T) {
 	}
 }
 
-// NewTestFS creates an in-memory fs.FS for testing.
+func TestAppFilesystem_BrandInjection(t *testing.T) {
+	brandJSON := `{"tagline":"Custom Portal","logoUrl":"https://example.com/logo.svg","social":{"github":"https://github.com/test"}}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head></head><body><h1>Hello</h1></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: brandJSON,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	if !strings.Contains(contentStr, "window.VITE_PORTAL_BRAND = ") {
+		t.Errorf("Modified index.html does not contain VITE_PORTAL_BRAND: %s", contentStr)
+	}
+
+	// Brand value should be JSON-stringified (double-quoted string)
+	if !strings.Contains(contentStr, `window.VITE_PORTAL_BRAND = "{\"tagline\":\"Custom Portal\"`) {
+		t.Errorf("VITE_PORTAL_BRAND not properly JSON-encoded: %s", contentStr)
+	}
+
+	// Should have 3 script tags: domain, isRoot, brand
+	scriptCount := strings.Count(contentStr, `<script type="text/javascript">`)
+	if scriptCount != 3 {
+		t.Errorf("Expected 3 script tags, got %d: %s", scriptCount, contentStr)
+	}
+}
+
+func TestAppFilesystem_BrandLogoReplacement(t *testing.T) {
+	brandJSON := `{"logoUrl":"https://branded.com/logo.png"}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head></head><body><div data-loader-logo class="w-28 h-28"><svg>old</svg></div></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: brandJSON,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	if !strings.Contains(contentStr, `<img alt="Logo" src="https://branded.com/logo.png"`) {
+		t.Errorf("Logo not replaced: %s", contentStr)
+	}
+
+	if strings.Contains(contentStr, "<svg>old</svg>") {
+		t.Errorf("Old logo content not removed: %s", contentStr)
+	}
+
+	// data-loader-logo div should still exist
+	if !strings.Contains(contentStr, `data-loader-logo`) {
+		t.Errorf("data-loader-logo div removed: %s", contentStr)
+	}
+}
+
+func TestAppFilesystem_BrandWithoutLogoNoReplacement(t *testing.T) {
+	brandJSON := `{"tagline":"No Logo Portal"}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head></head><body><div data-loader-logo class="w-28 h-28"><svg>old</svg></div></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: brandJSON,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Original logo content should still be present when no logoUrl
+	if !strings.Contains(contentStr, "<svg>old</svg>") {
+		t.Errorf("Original logo content should not be replaced when no logoUrl: %s", contentStr)
+	}
+}
+
+func TestAppFilesystem_BrandOnlyNoDomain(t *testing.T) {
+	brandJSON := `{"tagline":"Brand Only"}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head></head><body></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{BrandJSON: brandJSON})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	if strings.Contains(contentStr, "VITE_PORTAL_DOMAIN") {
+		t.Errorf("Should not contain VITE_PORTAL_DOMAIN when domain not set: %s", contentStr)
+	}
+
+	if !strings.Contains(contentStr, "VITE_PORTAL_BRAND") {
+		t.Errorf("Should contain VITE_PORTAL_BRAND: %s", contentStr)
+	}
+}
+
+func TestAppFilesystem_InvalidBrandJSON(t *testing.T) {
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head></head><body></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: `{invalid json`,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Domain vars should still work even with invalid brand JSON
+	if !strings.Contains(contentStr, "window.VITE_PORTAL_DOMAIN = 'example.com'") {
+		t.Errorf("Domain injection should still work with invalid brand JSON: %s", contentStr)
+	}
+
+	// Brand should still be injected (as a string, json.Marshal will handle it)
+	if !strings.Contains(contentStr, "window.VITE_PORTAL_BRAND = ") {
+		t.Errorf("Brand should still be injected even with invalid JSON object: %s", contentStr)
+	}
+
+	// No logo replacement should happen when JSON parsing fails
+	if appFS.brandLogoURL != "" {
+		t.Errorf("brandLogoURL should be empty when brand JSON parsing fails")
+	}
+}
+
 func findHeadElement(doc *html.Node) *html.Node {
 	var head *html.Node
 	var f func(*html.Node)
@@ -282,22 +482,17 @@ func NewTestFS(files map[string]string) fs.FS {
 }
 
 func TestAppFilesystemIntegration(t *testing.T) {
-	// Create a test file system
 	fsys := NewTestFS(map[string]string{
 		DefaultIndexFile: `<html><head><title>Test</title></head><body><h1>Hello</h1></body></html>`,
 		"static/app.js":  `console.log("app.js");`,
 	})
 
-	// Create an AppFilesystem instance
-	portalDomain := "example.com"
-	appFS := NewAppFilesystem(fsys, portalDomain)
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{Domain: "example.com"})
 
-	// Create a test HTTP server
 	handler := http.FileServer(http.FS(appFS))
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	// Make a request to the index file
 	resp, err := http.Get(server.URL + "/" + DefaultIndexFile)
 	if err != nil {
 		t.Fatalf("Failed to make request: %v", err)
@@ -309,24 +504,20 @@ func TestAppFilesystemIntegration(t *testing.T) {
 		}
 	}(resp.Body)
 
-	// Check the response status code
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
 	}
 
-	// Read the response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Failed to read response body: %v", err)
 	}
 
-	// Check if the portal domain is injected correctly
 	bodyStr := string(body)
 	if !strings.Contains(bodyStr, "window.VITE_PORTAL_DOMAIN = 'example.com'") {
 		t.Errorf("Response body does not contain portal domain: %s", bodyStr)
 	}
 
-	// Make a request to a static file
 	resp, err = http.Get(server.URL + "/static/app.js")
 	if err != nil {
 		t.Fatalf("Failed to make request: %v", err)
@@ -338,18 +529,15 @@ func TestAppFilesystemIntegration(t *testing.T) {
 		}
 	}(resp.Body)
 
-	// Check the response status code
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
 	}
 
-	// Read the response body
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Failed to read response body: %v", err)
 	}
 
-	// Check if the static file content is correct
 	bodyStr = string(body)
 	if !strings.Contains(bodyStr, `console.log("app.js");`) {
 		t.Errorf("Response body does not contain correct static file content: %s", bodyStr)

--- a/app_fs_test.go
+++ b/app_fs_test.go
@@ -341,6 +341,45 @@ func TestAppFilesystem_BrandLogoReplacement(t *testing.T) {
 	}
 }
 
+func TestAppFilesystem_BrandLogoReplacementBareAttribute(t *testing.T) {
+	brandJSON := `{"logoUrl":"https://branded.com/logo.png"}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head></head><body><div data-loader-logo><svg>old</svg></div></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: brandJSON,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	if !strings.Contains(contentStr, `<img alt="Logo" src="https://branded.com/logo.png"`) {
+		t.Errorf("Logo not replaced for bare data-loader-logo: %s", contentStr)
+	}
+
+	if strings.Contains(contentStr, "<svg>old</svg>") {
+		t.Errorf("Old logo content not removed: %s", contentStr)
+	}
+}
+
 func TestAppFilesystem_BrandWithoutLogoNoReplacement(t *testing.T) {
 	brandJSON := `{"tagline":"No Logo Portal"}`
 


### PR DESCRIPTION
- Replace NewAppFilesystem(fsys, domain) with NewAppFilesystem(fsys, AppFilesystemConfig{})
- Inject each env var as separate <script> tag matching Vite plugin output
- Add VITE_PORTAL_BRAND injection from BrandJSON config field
- Add data-loader-logo div replacement when brand has logoUrl
- Remove text/template dependency, build script content directly
- Update tests for new API and add brand/logo tests

---

<!-- kody-pr-summary:start -->
Add `VITE_PORTAL_BRAND` support to AppFilesystem, enabling brand configuration injection into the served index.html. The `NewAppFilesystem` constructor now accepts an `AppFilesystemConfig` struct (with `Domain` and `BrandJSON` fields) instead of a plain domain string. When `BrandJSON` is provided, a `window.VITE_PORTAL_BRAND` variable is injected as a JSON-stringified string into its own script tag. If the brand JSON contains a `logoUrl`, the inner content of any `<div data-loader-logo>` element in the HTML is replaced with an `<img>` tag pointing to that URL. The script injection logic was also refactored: each variable (`VITE_PORTAL_DOMAIN`, `VITE_PORTAL_DOMAIN_IS_ROOT`, `VITE_PORTAL_BRAND`) now gets its own separate `<script>` tag instead of being combined in a single template-rendered script, and the Go `text/template` dependency was removed in favor of direct string formatting.
<!-- kody-pr-summary:end -->