### PR TITLE
feat: add favicon replacement via brand.faviconUrl

### DIFF
--- a/app_fs.go
+++ b/app_fs.go
@@ -115,12 +115,12 @@ func (a *AppFilesystem) modifyIndexHTML(content []byte) []byte {
 	}
 
 	// Favicon href replacement on raw HTML — same regex approach as logo.
-	// No HTML escaping needed: the URL is inserted between matched quotes
-	// in the regex, so it cannot break out of the attribute.
-	// Use ${1}/${3} syntax so the URL's first char isn't absorbed into the
-	// group reference name (e.g. "$1https" would be read as group "1h").
+	// Escape HTML special chars in the URL (consistent with logo replacement)
+	// and escape $ to $$ so ReplaceAll doesn't interpret them as group refs.
 	if a.brandFaviconURL != "" {
-		replacement := []byte(fmt.Sprintf(`${1}%s${3}`, a.brandFaviconURL))
+		favEscaped := html.EscapeString(a.brandFaviconURL)
+		favEscaped = strings.ReplaceAll(favEscaped, "$", "$$")
+		replacement := []byte(fmt.Sprintf(`${1}%s${3}`, favEscaped))
 		content = faviconLinkRe.ReplaceAll(content, replacement)
 	}
 

--- a/app_fs.go
+++ b/app_fs.go
@@ -20,13 +20,17 @@ var _ fs.FileInfo = (*appFileInfo)(nil)
 // loaderLogoRe matches <div data-loader-logo ...>inner content</div>
 var loaderLogoRe = regexp.MustCompile(`(<div\s+data-loader-logo(?:\s+[^>]*)?>)([\s\S]*?)(</div>)`)
 
+// faviconLinkRe matches <link rel="icon" ... href="..."> to replace the href
+var faviconLinkRe = regexp.MustCompile(`(<link\s+rel=["']icon["'][^>]*\shref=["'])([^"']*)(["'])`)
+
 type AppFilesystemConfig struct {
 	Domain    string
 	BrandJSON string
 }
 
 type BrandConfig struct {
-	LogoURL string `json:"logoUrl"`
+	LogoURL    string `json:"logoUrl"`
+	FaviconURL string `json:"faviconUrl"`
 }
 
 // AppFilesystem wraps an fs.FS to modify index.html content before serving it.
@@ -38,7 +42,8 @@ type AppFilesystem struct {
 	mu           sync.Mutex
 	config       AppFilesystemConfig
 	isSubdomain  bool
-	brandLogoURL string
+	brandLogoURL    string
+	brandFaviconURL string
 }
 
 // NewAppFilesystem creates a new AppFilesystem wrapping the provided fs.FS.
@@ -56,6 +61,7 @@ func NewAppFilesystem(fsys fs.FS, config AppFilesystemConfig) *AppFilesystem {
 		var brand BrandConfig
 		if err := json.Unmarshal([]byte(config.BrandJSON), &brand); err == nil {
 			a.brandLogoURL = brand.LogoURL
+			a.brandFaviconURL = brand.FaviconURL
 		}
 	}
 
@@ -106,6 +112,16 @@ func (a *AppFilesystem) modifyIndexHTML(content []byte) []byte {
 	if a.brandLogoURL != "" {
 		replacement := fmt.Sprintf(`$1<img alt="Logo" src="%s" />$3`, html.EscapeString(a.brandLogoURL))
 		content = loaderLogoRe.ReplaceAll(content, []byte(replacement))
+	}
+
+	// Favicon href replacement on raw HTML — same regex approach as logo.
+	// No HTML escaping needed: the URL is inserted between matched quotes
+	// in the regex, so it cannot break out of the attribute.
+	// Use ${1}/${3} syntax so the URL's first char isn't absorbed into the
+	// group reference name (e.g. "$1https" would be read as group "1h").
+	if a.brandFaviconURL != "" {
+		replacement := []byte(fmt.Sprintf(`${1}%s${3}`, a.brandFaviconURL))
+		content = faviconLinkRe.ReplaceAll(content, replacement)
 	}
 
 	doc, err := html.Parse(bytes.NewReader(content))

--- a/app_fs_test.go
+++ b/app_fs_test.go
@@ -496,6 +496,120 @@ func TestAppFilesystem_InvalidBrandJSON(t *testing.T) {
 	}
 }
 
+func TestAppFilesystem_BrandFaviconReplacement(t *testing.T) {
+	brandJSON := `{"faviconUrl":"https://branded.com/favicon.ico"}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head><link rel="icon" type="image/svg+xml" href="/favicon.svg" /></head><body></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: brandJSON,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	if !strings.Contains(contentStr, `href="https://branded.com/favicon.ico"`) {
+		t.Errorf("Favicon href not replaced: %s", contentStr)
+	}
+
+	if strings.Contains(contentStr, "/favicon.svg") {
+		t.Errorf("Original favicon href still present: %s", contentStr)
+	}
+}
+
+func TestAppFilesystem_BrandFaviconAndLogoReplacement(t *testing.T) {
+	brandJSON := `{"faviconUrl":"/custom-favicon.png","logoUrl":"https://branded.com/logo.png"}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head><link rel="icon" type="image/svg+xml" href="/favicon.svg" /></head><body><div data-loader-logo><svg>old</svg></div></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: brandJSON,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	if !strings.Contains(contentStr, `href="/custom-favicon.png"`) {
+		t.Errorf("Favicon href not replaced: %s", contentStr)
+	}
+
+	if !strings.Contains(contentStr, `<img alt="Logo" src="https://branded.com/logo.png"`) {
+		t.Errorf("Logo not replaced: %s", contentStr)
+	}
+}
+
+func TestAppFilesystem_BrandWithoutFaviconNoReplacement(t *testing.T) {
+	brandJSON := `{"logoUrl":"https://branded.com/logo.png"}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head><link rel="icon" type="image/svg+xml" href="/favicon.svg" /></head><body></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: brandJSON,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Original favicon should still be present when no faviconUrl
+	if !strings.Contains(contentStr, "/favicon.svg") {
+		t.Errorf("Original favicon should not be replaced when no faviconUrl: %s", contentStr)
+	}
+}
+
 func findHeadElement(doc *html.Node) *html.Node {
 	var head *html.Node
 	var f func(*html.Node)

--- a/app_fs_test.go
+++ b/app_fs_test.go
@@ -610,6 +610,42 @@ func TestAppFilesystem_BrandWithoutFaviconNoReplacement(t *testing.T) {
 	}
 }
 
+func TestAppFilesystem_BrandFaviconSpecialChars(t *testing.T) {
+	brandJSON := `{"faviconUrl":"https://cdn.example.com/favicon?v=1&x=$2"}`
+
+	fsys := NewTestFS(map[string]string{
+		DefaultIndexFile: `<html><head><link rel="icon" type="image/svg+xml" href="/favicon.svg" /></head><body></body></html>`,
+	})
+
+	appFS := NewAppFilesystem(fsys, AppFilesystemConfig{
+		Domain:    "example.com",
+		BrandJSON: brandJSON,
+	})
+
+	file, err := appFS.Open(DefaultIndexFile)
+	if err != nil {
+		t.Fatalf("Failed to open index.html: %v", err)
+	}
+	defer func(file fs.File) {
+		err = file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}(file)
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read index.html: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// & should be HTML-escaped to &amp;
+	if !strings.Contains(contentStr, `href="https://cdn.example.com/favicon?v=1&amp;x=$2"`) {
+		t.Errorf("Favicon URL with special chars not properly escaped: %s", contentStr)
+	}
+}
+
 func findHeadElement(doc *html.Node) *html.Node {
 	var head *html.Node
 	var f func(*html.Node)


### PR DESCRIPTION
Adds `faviconUrl` to `BrandConfig` so the favicon can be customized per deployment through the `VITE_PORTAL_BRAND` JSON, matching the existing `logoUrl` pattern.

**Changes:**
- `BrandConfig` struct: add `FaviconURL` field
- `faviconLinkRe` regex: matches `<link rel="icon" ... href="...">` and replaces the href
- `modifyIndexHTML`: applies favicon replacement before DOM parsing, same approach as logo
- 3 test cases: favicon-only, favicon+logo, no-favicon (no replacement)

Companion to the web repo change that added `faviconUrl` to the `BrandConfig` schema and the Vite plugin `transformIndexHtml` hook.

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds support for replacing the favicon URL in the served `index.html` based on brand configuration, extending the existing branding capabilities (which already supported logo replacement).

### Changes

**Brand Configuration:**
- Added a new `faviconUrl` field to the `BrandConfig` struct, allowing brand configurations to specify a custom favicon URL alongside the existing `logoUrl`.

**Favicon Replacement Logic:**
- Introduced a regex pattern (`faviconLinkRe`) that matches `<link rel="icon" ... href="...">` tags in the HTML.
- When a `faviconUrl` is provided in the brand config, the favicon `href` attribute in `index.html` is replaced with the branded URL before serving. If no `faviconUrl` is configured, the original favicon is left unchanged.

**Tests:**
- Added three test cases covering:
  - Favicon replacement when only `faviconUrl` is provided.
  - Simultaneous favicon and logo replacement when both are configured.
  - Ensuring the original favicon is preserved when `faviconUrl` is absent from the brand config.
<!-- kody-pr-summary:end -->