### PR TITLE
feat: add FieldEnums() to FieldSchema for enum support in filter params

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -23,6 +23,7 @@ type SwaggerOption func(*swagger.Definitions, string)
 type FieldSchema interface {
 	SortableFields() []string
 	FilterOperators() map[string][]string // field -> []operator
+	FieldEnums() map[string][]string     // field -> []enum values (optional, may return nil)
 }
 
 // SchemaProvider defines an interface for providing schema information
@@ -571,7 +572,9 @@ func WithFilterParam(name, description string, schemaValue any) SwaggerOption {
 func WithFilterParamsFromSchema(schema FieldSchema) SwaggerOption {
 	return func(d *swagger.Definitions, accessRole string) {
 		operators := schema.FilterOperators()
+		enums := schema.FieldEnums()
 		for fieldName, ops := range operators {
+			fieldEnum, hasEnum := enums[fieldName]
 			for _, op := range ops {
 				// Validate operator string
 				if _, exists := operatorDocs[op]; !exists {
@@ -588,28 +591,46 @@ func WithFilterParamsFromSchema(schema FieldSchema) SwaggerOption {
 
 				if isArrayOp {
 					// Array parameter schema
+					itemsSchema := map[string]interface{}{
+						"type": "string", // Will be converted by parser
+					}
+					if hasEnum {
+						itemsSchema["enum"] = fieldEnum
+					}
 					*d = SwaggerFilterParam(*d, simpleParam, paramDesc,
 						map[string]interface{}{
-							"type": "array",
-							"items": map[string]interface{}{
-								"type": "string", // Will be converted by parser
-							},
-							"style":              "form",
-							"explode":            false,
-							"x-csv":              true,
+							"type":              "array",
+							"items":             itemsSchema,
+							"style":             "form",
+							"explode":           false,
+							"x-csv":             true,
 							"x-collectionFormat": "multi",
 						})
 				} else {
 					// Single value parameter
-					*d = SwaggerFilterParam(*d, simpleParam, paramDesc, "")
+					schemaValue := any("")
+					if hasEnum {
+						schemaValue = map[string]any{
+							"type": "string",
+							"enum": fieldEnum,
+						}
+					}
+					*d = SwaggerFilterParam(*d, simpleParam, paramDesc, schemaValue)
 				}
 
 				// Add complex format param
+				complexSchemaValue := any("")
+				if hasEnum {
+					complexSchemaValue = map[string]any{
+						"type": "string",
+						"enum": fieldEnum,
+					}
+				}
 				complexParam := fmt.Sprintf("filters[%s][%s]", fieldName, op)
 				*d = SwaggerFilterParam(*d, complexParam,
 					fmt.Sprintf("Filter by %s %s",
 						fieldName, strings.ToLower(op)),
-					"")
+					complexSchemaValue)
 			}
 		}
 	}

--- a/swagger.go
+++ b/swagger.go
@@ -621,9 +621,20 @@ func WithFilterParamsFromSchema(schema FieldSchema) SwaggerOption {
 				// Add complex format param
 				complexSchemaValue := any("")
 				if hasEnum {
-					complexSchemaValue = map[string]any{
-						"type": "string",
-						"enum": fieldEnum,
+					if isArrayOp {
+						complexSchemaValue = map[string]any{
+							"type":              "array",
+							"items":             map[string]any{"type": "string", "enum": fieldEnum},
+							"style":             "form",
+							"explode":           false,
+							"x-csv":             true,
+							"x-collectionFormat": "multi",
+						}
+					} else {
+						complexSchemaValue = map[string]any{
+							"type": "string",
+							"enum": fieldEnum,
+						}
 					}
 				}
 				complexParam := fmt.Sprintf("filters[%s][%s]", fieldName, op)

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -35,6 +35,31 @@ func (s *testSchema) SortableFields() []string {
 	return []string{"age", "name"}
 }
 
+func (s *testSchema) FieldEnums() map[string][]string {
+	return nil
+}
+
+// testSchemaWithEnums implements FieldSchema with enum values
+type testSchemaWithEnums struct{}
+
+func (s *testSchemaWithEnums) FilterOperators() map[string][]string {
+	return map[string][]string{
+		"status": {"eq", "ne"},
+		"level":  {"in"},
+	}
+}
+
+func (s *testSchemaWithEnums) SortableFields() []string {
+	return []string{"status"}
+}
+
+func (s *testSchemaWithEnums) FieldEnums() map[string][]string {
+	return map[string][]string{
+		"status": {"pending", "processing", "completed", "failed"},
+		"level":  {"info", "warn", "error"},
+	}
+}
+
 func TestWithSwaggerOptions(t *testing.T) {
 	handler := func(c echo.Context) error { return nil }
 
@@ -348,6 +373,20 @@ func TestWithFilterParamsFromSchema(t *testing.T) {
 			wantArrayOps:  []string{"age_between"},
 			wantDescRegex: `Filter by (age|name)`,
 		},
+		{
+			name:   "field operators with enums",
+			schema: &testSchemaWithEnums{},
+			wantParams: []string{
+				"status_eq",
+				"status_ne",
+				"level_in",
+				"filters[status][eq]",
+				"filters[status][ne]",
+				"filters[level][in]",
+			},
+			wantArrayOps:  []string{"level_in"},
+			wantDescRegex: `Filter by (status|level)`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -382,7 +421,30 @@ func TestWithFilterParamsFromSchema(t *testing.T) {
 					assert.Contains(t, param, "[", "complex format param should contain brackets")
 					assert.Contains(t, param, "]", "complex format param should contain brackets")
 				}
+			}
 
+			// Verify enum values appear in schema for enum-bearing fields
+			if tt.name == "field operators with enums" {
+				// Single-value param (status_eq) should have enum
+				statusEqSchema := def.Querystring["status_eq"].Schema.Value
+				statusMap, ok := statusEqSchema.(map[string]any)
+				require.True(t, ok, "expected map schema for status_eq")
+				assert.Equal(t, "string", statusMap["type"])
+				assert.ElementsMatch(t, []string{"pending", "processing", "completed", "failed"}, statusMap["enum"])
+
+				// Complex format param (filters[status][eq]) should have enum
+				complexSchema := def.Querystring["filters[status][eq]"].Schema.Value
+				complexMap, ok := complexSchema.(map[string]any)
+				require.True(t, ok, "expected map schema for filters[status][eq]")
+				assert.ElementsMatch(t, []string{"pending", "processing", "completed", "failed"}, complexMap["enum"])
+
+				// Array param (level_in) should have enum in items
+				levelInSchema := def.Querystring["level_in"].Schema.Value
+				levelMap, ok := levelInSchema.(map[string]any)
+				require.True(t, ok, "expected map schema for level_in")
+				items, ok := levelMap["items"].(map[string]any)
+				require.True(t, ok, "expected items map for level_in")
+				assert.ElementsMatch(t, []string{"info", "warn", "error"}, items["enum"])
 			}
 		})
 	}

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -445,7 +445,18 @@ func TestWithFilterParamsFromSchema(t *testing.T) {
 				items, ok := levelMap["items"].(map[string]any)
 				require.True(t, ok, "expected items map for level_in")
 				assert.ElementsMatch(t, []string{"info", "warn", "error"}, items["enum"])
-			}
+
+				// Complex format array+enum param (filters[level][in]) should be
+				// an array schema with enum in items, not a string+enum
+				complexArraySchema := def.Querystring["filters[level][in]"].Schema.Value
+				complexArrayMap, ok := complexArraySchema.(map[string]any)
+				require.True(t, ok, "expected map schema for filters[level][in]")
+				assert.Equal(t, "array", complexArrayMap["type"],
+					"filters[level][in] should be array type for multi-value operator")
+				complexItems, ok := complexArrayMap["items"].(map[string]any)
+				require.True(t, ok, "expected items map for filters[level][in]")
+				assert.ElementsMatch(t, []string{"info", "warn", "error"}, complexItems["enum"])
+				}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Adds FieldEnums() map[string][]string to the FieldSchema interface
- WithFilterParamsFromSchema now generates enum constraints in the OpenAPI spec for fields with enum values
- Covers single-value, array, and complex filter parameter formats

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds enum support to filter parameters in the Swagger documentation generation.

### Changes

**New `FieldEnums()` method on `FieldSchema` interface**: Introduces an optional method that allows schema implementations to declare allowed enum values per field. Fields without enums can return `nil`.

**Enhanced `WithFilterParamsFromSchema`**: When a field has enum values defined, the generated Swagger parameter schemas now include the `enum` constraint. This applies to all three parameter formats:
- **Single-value parameters** (e.g., `status_eq`): Schema includes `type: string` and the allowed `enum` values.
- **Complex format parameters** (e.g., `filters[status][eq]`): Same enum constraint applied.
- **Array parameters** (e.g., `level_in`): The `items` schema within the array includes the `enum` values.

Fields without enum values continue to generate schemas as before (plain string type), ensuring backward compatibility.

### Purpose

This allows API consumers to discover which values are valid for filtered fields (such as `status` or `level` fields with fixed allowed values) directly from the generated Swagger documentation, improving API usability and reducing invalid query attempts.
<!-- kody-pr-summary:end -->